### PR TITLE
Fix handling of existing session after re-login

### DIFF
--- a/CSharpDemoIBAutomater/CSharpDemoIBAutomater.csproj
+++ b/CSharpDemoIBAutomater/CSharpDemoIBAutomater.csproj
@@ -39,7 +39,7 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="QuantConnect.IBAutomater, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.IBAutomater.1.0.3\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
+      <HintPath>..\packages\QuantConnect.IBAutomater.1.0.4\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -56,14 +56,16 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\QuantConnect.IBAutomater.1.0.3\build\QuantConnect.IBAutomater.targets" Condition="Exists('..\packages\QuantConnect.IBAutomater.1.0.3\build\QuantConnect.IBAutomater.targets')" />
+  <Import Project="..\packages\QuantConnect.IBAutomater.1.0.4\build\QuantConnect.IBAutomater.targets" Condition="Exists('..\packages\QuantConnect.IBAutomater.1.0.4\build\QuantConnect.IBAutomater.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.IBAutomater.1.0.3\build\QuantConnect.IBAutomater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.IBAutomater.1.0.3\build\QuantConnect.IBAutomater.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.IBAutomater.1.0.4\build\QuantConnect.IBAutomater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.IBAutomater.1.0.4\build\QuantConnect.IBAutomater.targets'))" />
   </Target>
 </Project>

--- a/CSharpDemoIBAutomater/CSharpDemoIBAutomater.csproj
+++ b/CSharpDemoIBAutomater/CSharpDemoIBAutomater.csproj
@@ -39,7 +39,7 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="QuantConnect.IBAutomater, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.IBAutomater.1.0.2\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
+      <HintPath>..\packages\QuantConnect.IBAutomater.1.0.3\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -59,11 +59,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\QuantConnect.IBAutomater.1.0.2\build\QuantConnect.IBAutomater.targets" Condition="Exists('..\packages\QuantConnect.IBAutomater.1.0.2\build\QuantConnect.IBAutomater.targets')" />
+  <Import Project="..\packages\QuantConnect.IBAutomater.1.0.3\build\QuantConnect.IBAutomater.targets" Condition="Exists('..\packages\QuantConnect.IBAutomater.1.0.3\build\QuantConnect.IBAutomater.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.IBAutomater.1.0.2\build\QuantConnect.IBAutomater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.IBAutomater.1.0.2\build\QuantConnect.IBAutomater.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.IBAutomater.1.0.3\build\QuantConnect.IBAutomater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.IBAutomater.1.0.3\build\QuantConnect.IBAutomater.targets'))" />
   </Target>
 </Project>

--- a/CSharpDemoIBAutomater/packages.config
+++ b/CSharpDemoIBAutomater/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
-  <package id="QuantConnect.IBAutomater" version="1.0.3" targetFramework="net452" />
+  <package id="QuantConnect.IBAutomater" version="1.0.4" targetFramework="net452" />
 </packages>

--- a/CSharpDemoIBAutomater/packages.config
+++ b/CSharpDemoIBAutomater/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
-  <package id="QuantConnect.IBAutomater" version="1.0.2" targetFramework="net452" />
+  <package id="QuantConnect.IBAutomater" version="1.0.3" targetFramework="net452" />
 </packages>

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -328,12 +328,15 @@ public class WindowEventListener implements AWTEventListener {
         String title = Common.getTitle(window);
 
         if (title != null && title.equals("Existing session detected")) {
-            String buttonText = isPerformingRelogin ? "Continue Login" : "Exit Application";
+            String buttonText = isPerformingRelogin ? "Reconnect This Session" : "Exit Application";
             JButton button = Common.getButton(window, buttonText);
 
             if (button != null) {
                 this.automater.logMessage("Click button: [" + buttonText + "]");
                 button.doClick();
+            }
+            else {
+                this.automater.logMessage("Button not found: [" + buttonText + "]");
             }
 
             return true;

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -40,6 +40,7 @@ public class WindowEventListener implements AWTEventListener {
             this.put(WindowEvent.WINDOW_CLOSED, "WINDOW_CLOSED");
         }
     };
+    private boolean isPerformingRelogin = false;
 
     WindowEventListener(IBAutomater automater) {
         this.automater = automater;
@@ -230,6 +231,8 @@ public class WindowEventListener implements AWTEventListener {
         String title = Common.getTitle(window);
 
         if (title != null && title.contains("Starting application...")) {
+            isPerformingRelogin = false;
+
             JMenuItem menuItem = Common.getMenuItem(this.automater.getMainWindow(), "Configure", "Settings");
             menuItem.doClick();
 
@@ -325,7 +328,7 @@ public class WindowEventListener implements AWTEventListener {
         String title = Common.getTitle(window);
 
         if (title != null && title.equals("Existing session detected")) {
-            String buttonText = "Exit Application";
+            String buttonText = isPerformingRelogin ? "Continue Login" : "Exit Application";
             JButton button = Common.getButton(window, buttonText);
 
             if (button != null) {
@@ -351,6 +354,7 @@ public class WindowEventListener implements AWTEventListener {
             JButton button = Common.getButton(window, buttonText);
 
             if (button != null) {
+                isPerformingRelogin = true;
                 this.automater.logMessage("Click button: [" + buttonText + "]");
                 button.doClick();
             }


### PR DESCRIPTION
When a user is disconnected because of a remote login, the **"Re-login is required"** dialog is opened and the **"Re-login"** button will be clicked:
![image](https://user-images.githubusercontent.com/7236689/60747911-05505f00-9f89-11e9-9bd3-11369fa470bb.png)

Since the remote session is logged in, the **"Existing session detected"** window is opened and the **"Reconnect This Session"** button will be clicked:
![image](https://user-images.githubusercontent.com/7236689/60747960-860f5b00-9f89-11e9-8f1d-caac7b97cccf.png)

On the other hand, if a user attempts to login (at startup) when another session is already logged on, the 
**"Existing session detected"** window is opened (with the **"Continue Login"** button instead) but in this case the **"Exit Application"** button will be clicked:
![image](https://user-images.githubusercontent.com/7236689/60748044-4a28c580-9f8a-11e9-9ae8-b202ad84bcd0.png)
