### PR TITLE
fix setting configurations for ibgateway 978

### DIFF
--- a/java/IBAutomater/src/ibautomater/Common.java
+++ b/java/IBAutomater/src/ibautomater/Common.java
@@ -103,20 +103,17 @@ public class Common {
     }
 
     public static JMenuItem getMenuItem(Container container, String menuText, String menuItemText) {
-        try {
-            JMenuBar menuBar = ((JFrame) container).getJMenuBar();
-            for (int i = 0; i < menuBar.getMenuCount(); ++i) {
-                JMenu menu = menuBar.getMenu(i);
-                if (!menu.getText().equals(menuText)) continue;
-                for (int j = 0; j < menu.getItemCount(); ++j) {
-                    JMenuItem menuItem = menu.getItem(j);
-                    if (menuItem == null || !menuItem.getText().equalsIgnoreCase(menuItemText)) continue;
-                    return menuItem;
-                }
+        if (container == null) return null;
+        JMenuBar menuBar = ((JFrame) container).getJMenuBar();
+        if (menuBar == null) return null;
+        for (int i = 0; i < menuBar.getMenuCount(); ++i) {
+            JMenu menu = menuBar.getMenu(i);
+            if (!menu.getText().equals(menuText)) continue;
+            for (int j = 0; j < menu.getItemCount(); ++j) {
+                JMenuItem menuItem = menu.getItem(j);
+                if (menuItem == null || !menuItem.getText().equalsIgnoreCase(menuItemText)) continue;
+                return menuItem;
             }
-        }
-        catch (Exception e) {
-            return null;
         }
         return null;
     }

--- a/java/IBAutomater/src/ibautomater/Common.java
+++ b/java/IBAutomater/src/ibautomater/Common.java
@@ -103,15 +103,20 @@ public class Common {
     }
 
     public static JMenuItem getMenuItem(Container container, String menuText, String menuItemText) {
-        JMenuBar menuBar = ((JFrame)container).getJMenuBar();
-        for (int i = 0; i < menuBar.getMenuCount(); ++i) {
-            JMenu menu = menuBar.getMenu(i);
-            if (!menu.getText().equals(menuText)) continue;
-            for (int j = 0; j < menu.getItemCount(); ++j) {
-                JMenuItem menuItem = menu.getItem(j);
-                if (menuItem == null || !menuItem.getText().equalsIgnoreCase(menuItemText)) continue;
-                return menuItem;
+        try {
+            JMenuBar menuBar = ((JFrame) container).getJMenuBar();
+            for (int i = 0; i < menuBar.getMenuCount(); ++i) {
+                JMenu menu = menuBar.getMenu(i);
+                if (!menu.getText().equals(menuText)) continue;
+                for (int j = 0; j < menu.getItemCount(); ++j) {
+                    JMenuItem menuItem = menu.getItem(j);
+                    if (menuItem == null || !menuItem.getText().equalsIgnoreCase(menuItemText)) continue;
+                    return menuItem;
+                }
             }
+        }
+        catch (Exception e) {
+            return null;
         }
         return null;
     }

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -240,7 +240,27 @@ public class WindowEventListener implements AWTEventListener {
         String title = Common.getTitle(window);
 
         if (title != null && title.contains("Starting application...")) {
-            JMenuItem menuItem = Common.getMenuItem(this.automater.getMainWindow(), "Configure", "Settings");
+            Window mainWindow = this.automater.getMainWindow();
+            JMenuItem menuItem = null;
+
+            if (mainWindow == null) {
+                this.automater.logMessage("Main window is still null!");
+                this.automater.logMessage("Finding main window...");
+                for(Window w : Window.getWindows()) {
+                    String wTitle = Common.getTitle(w);
+                    if (wTitle.contains("IB Gateway")) {
+                        menuItem = Common.getMenuItem(w, "Configure", "Settings");
+                        if (menuItem != null) {
+                            this.automater.logMessage("Found main window!");
+                            this.automater.setMainWindow(w);
+                        }
+                    }
+                }
+            }
+            else {
+                menuItem = Common.getMenuItem(mainWindow, "Configure", "Settings");
+            }
+
             if (menuItem != null) {
                 menuItem.doClick();
                 return true;


### PR DESCRIPTION
For IB Gateway v978, it's possible for the main window to still be null when the `Starting application...` window is received because [setting the main window](https://github.com/QuantConnect/IBAutomater/blob/master/java/IBAutomater/src/ibautomater/WindowEventListener.java#L227) hasn't happened yet.

As a result, [`getMenuItem`](https://github.com/QuantConnect/IBAutomater/blob/master/java/IBAutomater/src/ibautomater/Common.java#L105) throws a `NullPointerException` and configuration settings are not updated.

`IBAutomater` fails to initialize (i.e., [this](https://github.com/QuantConnect/IBAutomater/blob/master/QuantConnect.IBAutomater/IBAutomater.cs#L222) doesn't happen) and times out. Lean Engine later exits because API is still in read-only mode.

Relevant logs from docker container:
![image](https://user-images.githubusercontent.com/591646/79373441-909d4e80-7f24-11ea-9514-e180de1a25d2.png)

![image](https://user-images.githubusercontent.com/591646/79374920-d0186a80-7f25-11ea-9076-8671f05682db.png)

Logs after fix:
![image](https://user-images.githubusercontent.com/591646/79373681-ea057d80-7f24-11ea-8722-67aa3cedebe6.png)

This fix is backwards compatible with IB Gateway v974.

 