### PR TITLE
Fix null title check in HandleLoginWindow

### DIFF
--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -107,7 +107,7 @@ public class WindowEventListener implements AWTEventListener {
 
         String title = Common.getTitle(window);
 
-        if (title != null && !title.equals("IB Gateway")) {
+        if (title == null || !title.equals("IB Gateway")) {
             return false;
         }
 


### PR DESCRIPTION
- The incorrect null check was causing this message to be logged when a popup window with no title was opened:
> "IB API toggle button not found"