### PR TITLE
Fix main window detection with IBGateway v978

### DIFF
--- a/CSharpDemoIBAutomater/CSharpDemoIBAutomater.csproj
+++ b/CSharpDemoIBAutomater/CSharpDemoIBAutomater.csproj
@@ -42,7 +42,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="QuantConnect.IBAutomater, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.IBAutomater.1.0.25\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
+      <HintPath>..\packages\QuantConnect.IBAutomater.1.0.26\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -66,11 +66,11 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\QuantConnect.IBAutomater.1.0.25\build\QuantConnect.IBAutomater.targets" Condition="Exists('..\packages\QuantConnect.IBAutomater.1.0.25\build\QuantConnect.IBAutomater.targets')" />
+  <Import Project="..\packages\QuantConnect.IBAutomater.1.0.26\build\QuantConnect.IBAutomater.targets" Condition="Exists('..\packages\QuantConnect.IBAutomater.1.0.26\build\QuantConnect.IBAutomater.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.IBAutomater.1.0.25\build\QuantConnect.IBAutomater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.IBAutomater.1.0.25\build\QuantConnect.IBAutomater.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.IBAutomater.1.0.26\build\QuantConnect.IBAutomater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.IBAutomater.1.0.26\build\QuantConnect.IBAutomater.targets'))" />
   </Target>
 </Project>

--- a/CSharpDemoIBAutomater/CSharpDemoIBAutomater.csproj
+++ b/CSharpDemoIBAutomater/CSharpDemoIBAutomater.csproj
@@ -42,7 +42,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="QuantConnect.IBAutomater, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.IBAutomater.1.0.23\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
+      <HintPath>..\packages\QuantConnect.IBAutomater.1.0.25\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -66,11 +66,11 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\QuantConnect.IBAutomater.1.0.23\build\QuantConnect.IBAutomater.targets" Condition="Exists('..\packages\QuantConnect.IBAutomater.1.0.23\build\QuantConnect.IBAutomater.targets')" />
+  <Import Project="..\packages\QuantConnect.IBAutomater.1.0.25\build\QuantConnect.IBAutomater.targets" Condition="Exists('..\packages\QuantConnect.IBAutomater.1.0.25\build\QuantConnect.IBAutomater.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.IBAutomater.1.0.23\build\QuantConnect.IBAutomater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.IBAutomater.1.0.23\build\QuantConnect.IBAutomater.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.IBAutomater.1.0.25\build\QuantConnect.IBAutomater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.IBAutomater.1.0.25\build\QuantConnect.IBAutomater.targets'))" />
   </Target>
 </Project>

--- a/CSharpDemoIBAutomater/packages.config
+++ b/CSharpDemoIBAutomater/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="QuantConnect.IBAutomater" version="1.0.23" targetFramework="net452" />
+  <package id="QuantConnect.IBAutomater" version="1.0.25" targetFramework="net452" />
 </packages>

--- a/CSharpDemoIBAutomater/packages.config
+++ b/CSharpDemoIBAutomater/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="QuantConnect.IBAutomater" version="1.0.25" targetFramework="net452" />
+  <package id="QuantConnect.IBAutomater" version="1.0.26" targetFramework="net452" />
 </packages>

--- a/java/IBAutomater/src/ibautomater/GetMainWindowTask.java
+++ b/java/IBAutomater/src/ibautomater/GetMainWindowTask.java
@@ -1,0 +1,51 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * IBAutomater v1.0. Copyright 2019 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package ibautomater;
+
+import java.awt.Window;
+import java.util.concurrent.Callable;
+import javax.swing.JMenuItem;
+
+public class GetMainWindowTask implements Callable<Window> {
+    private final IBAutomater automater;
+
+    GetMainWindowTask(IBAutomater automater) {
+        this.automater = automater;
+    }
+
+    @Override
+    @SuppressWarnings("SleepWhileInLoop")
+    public Window call() throws Exception {
+        while (true) {
+            this.automater.logMessage("Finding main window...");
+
+            for(Window w : Window.getWindows()) {
+                String wTitle = Common.getTitle(w);
+                if (wTitle.contains("IB Gateway")) {
+                    JMenuItem menuItem = Common.getMenuItem(w, "Configure", "Settings");
+                    if (menuItem != null) {
+                        this.automater.logMessage("Found main window.");
+                        return w;
+                    }
+                }
+            }
+
+            this.automater.logMessage("Main window not found.");
+
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -70,9 +70,6 @@ public class WindowEventListener implements AWTEventListener {
             if (this.HandlePasswordNoticeWindow(window, eventId)) {
                 return;
             }
-            if (this.HandleMainWindow(window, eventId)) {
-                return;
-            }
             if (this.HandleInitializationWindow(window, eventId)) {
                 return;
             }
@@ -215,23 +212,6 @@ public class WindowEventListener implements AWTEventListener {
         return false;
     }
 
-    private boolean HandleMainWindow(Window window, int eventId) {
-        if (eventId != WindowEvent.WINDOW_ACTIVATED &&
-            eventId != WindowEvent.WINDOW_OPENED) {
-            return false;
-        }
-
-        String title = Common.getTitle(window);
-
-        if (title != null && title.contains("IB Gateway")) {
-            this.automater.setMainWindow(window);
-
-            return true;
-        }
-
-        return false;
-    }
-
     private boolean HandleInitializationWindow(Window window, int eventId) throws Exception {
         if (eventId != WindowEvent.WINDOW_CLOSED) {
             return false;
@@ -240,25 +220,18 @@ public class WindowEventListener implements AWTEventListener {
         String title = Common.getTitle(window);
 
         if (title != null && title.contains("Starting application...")) {
-            Window mainWindow = this.automater.getMainWindow();
             JMenuItem menuItem = null;
 
-            if (mainWindow == null) {
-                this.automater.logMessage("Main window is still null!");
-                this.automater.logMessage("Finding main window...");
-                for(Window w : Window.getWindows()) {
-                    String wTitle = Common.getTitle(w);
-                    if (wTitle.contains("IB Gateway")) {
-                        menuItem = Common.getMenuItem(w, "Configure", "Settings");
-                        if (menuItem != null) {
-                            this.automater.logMessage("Found main window!");
-                            this.automater.setMainWindow(w);
-                        }
+            this.automater.logMessage("Finding main window...");
+            for(Window w : Window.getWindows()) {
+                String wTitle = Common.getTitle(w);
+                if (wTitle.contains("IB Gateway")) {
+                    menuItem = Common.getMenuItem(w, "Configure", "Settings");
+                    if (menuItem != null) {
+                        this.automater.logMessage("Found main window!");
+                        this.automater.setMainWindow(w);
                     }
                 }
-            }
-            else {
-                menuItem = Common.getMenuItem(mainWindow, "Configure", "Settings");
             }
 
             if (menuItem != null) {


### PR DESCRIPTION
The main window was occasionally not detected properly, causing initialization failure (with IBGateway v978).

A previous fix for this issue was merged in #13, but it was still possible to consistently repeat the issue.

With IBGateway v978 apparently something changed in the initial loading of the windows which made our current logic unreliable.

This is the failing case:
the main window is set here:
https://github.com/QuantConnect/IBAutomater/pull/18/files#diff-f99616d61473f68c66c3e17455eb4339L227
but this line returns null:
https://github.com/QuantConnect/IBAutomater/pull/18/files#diff-f99616d61473f68c66c3e17455eb4339L261

With the new simplified logic, the main window detection is all done in a single method and this check is now always returning true:
https://github.com/QuantConnect/IBAutomater/pull/18/files#diff-f99616d61473f68c66c3e17455eb4339R230

> Tested with both v974 and v978