### PR TITLE
Fix special character escaping in password (Windows only)

### DIFF
--- a/CSharpDemoIBAutomater/CSharpDemoIBAutomater.csproj
+++ b/CSharpDemoIBAutomater/CSharpDemoIBAutomater.csproj
@@ -42,7 +42,7 @@
       <HintPath>..\packages\NodaTime.1.3.4\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="QuantConnect.IBAutomater, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuantConnect.IBAutomater.1.0.35\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
+      <HintPath>..\packages\QuantConnect.IBAutomater.1.0.38\lib\net45\QuantConnect.IBAutomater.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -66,11 +66,11 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\QuantConnect.IBAutomater.1.0.35\build\QuantConnect.IBAutomater.targets" Condition="Exists('..\packages\QuantConnect.IBAutomater.1.0.35\build\QuantConnect.IBAutomater.targets')" />
+  <Import Project="..\packages\QuantConnect.IBAutomater.1.0.38\build\QuantConnect.IBAutomater.targets" Condition="Exists('..\packages\QuantConnect.IBAutomater.1.0.38\build\QuantConnect.IBAutomater.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\QuantConnect.IBAutomater.1.0.35\build\QuantConnect.IBAutomater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.IBAutomater.1.0.35\build\QuantConnect.IBAutomater.targets'))" />
+    <Error Condition="!Exists('..\packages\QuantConnect.IBAutomater.1.0.38\build\QuantConnect.IBAutomater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\QuantConnect.IBAutomater.1.0.38\build\QuantConnect.IBAutomater.targets'))" />
   </Target>
 </Project>

--- a/CSharpDemoIBAutomater/packages.config
+++ b/CSharpDemoIBAutomater/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NodaTime" version="1.3.4" targetFramework="net452" />
-  <package id="QuantConnect.IBAutomater" version="1.0.35" targetFramework="net452" />
+  <package id="QuantConnect.IBAutomater" version="1.0.38" targetFramework="net452" />
 </packages>

--- a/QuantConnect.IBAutomater/IBAutomater.bat
+++ b/QuantConnect.IBAutomater/IBAutomater.bat
@@ -1,1 +1,1 @@
-@"%7\bin\java.exe" -cp %1/ibgateway/%2/jars/*;./commons-cli-1.4.jar;./IBAutomater.jar ibautomater.IBAutomater -ibdir %1 -user %3 -pwd %4 -mode %5 -port %6
+@"%7\bin\java.exe" -cp %1/ibgateway/%2/jars/*;./commons-cli-1.4.jar;./IBAutomater.jar ibautomater.IBAutomater -ibdir %1 -user %3 -pwd "%4" -mode %5 -port %6

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -204,7 +204,7 @@ namespace QuantConnect.IBAutomater
                 }
 
                 var fileName = IsWindows ? "IBAutomater.bat" : "IBAutomater.sh";
-                var arguments = $"{_ibDirectory} {_ibVersion} {_userName} {_password} {_tradingMode} {_portNumber} {jreInstallPath}";
+                var arguments = $"{_ibDirectory} {_ibVersion} {_userName} {EscapePassword(_password)} {_tradingMode} {_portNumber} {jreInstallPath}";
 
                 var process = new Process
                 {
@@ -689,6 +689,13 @@ namespace QuantConnect.IBAutomater
             }
 
             return null;
+        }
+
+        private string EscapePassword(string password)
+        {
+            return IsWindows
+                ? password.Replace("&", "^&").Replace("|", "^|")
+                : password;
         }
     }
 }


### PR DESCRIPTION
- Passwords containing the special characters `"&"` and `"|"` were causing failed IB logins