### PR TITLE
change QuantConnect.IBAutomater.nuspec to multi-output

### DIFF
--- a/nuget/QuantConnect.IBAutomater.nuspec
+++ b/nuget/QuantConnect.IBAutomater.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>QuantConnect.IBAutomater</id>
-    <version>1.0.30</version>
+    <version>1.0.39</version>
     <authors>QuantConnect Corp.</authors>
     <owners>QuantConnect Corp.</owners>
     <license type="expression">Apache-2.0</license>
@@ -13,13 +13,37 @@
     <copyright>Copyright 2019</copyright>
     <tags>QuantConnect IBAutomater</tags>
     <dependencies>
-        <dependency id="Newtonsoft.Json" version="10.0.3" />
+        <group targetFramework=".NETFramework4.5.2">
+            <dependency id="Newtonsoft.Json" version="10.0.3" />
+            <dependency id="NodaTime" version="1.3.4" />
+        </group>
+        <group targetFramework="netcoreapp3.1">
+            <dependency id="Newtonsoft.Json" version="10.0.3" />
+            <dependency id="NodaTime" version="1.3.4" />
+        </group>
     </dependencies>
+		<references>
+			<group targetFramework="net452">
+				<reference file="QuantConnect.IBAutomater.exe" />
+				<reference file="QuantConnect.IBAutomater.pdb" />
+			</group>
+
+			<group targetFramework="netcoreapp3.1">
+				<reference file="QuantConnect.IBAutomater.exe" />
+				<reference file="QuantConnect.IBAutomater.pdb" />
+			</group>
+		</references>
   </metadata>
   <files>
-    <file src="net452\QuantConnect.IBAutomater.exe" target="lib\net45" />
-    <file src="net452\QuantConnect.IBAutomater.pdb" target="lib\net45" />
-    <file src="QuantConnect.IBAutomater.targets" target="build" />
+		<file src="net452\QuantConnect.IBAutomater.exe" target="ref/net452" />
+		<file src="net452\QuantConnect.IBAutomater.pdb" target="ref/net452" />
+		<file src="net452\QuantConnect.IBAutomater.exe" target="ref/netcoreapp3.1" />
+		<file src="net452\QuantConnect.IBAutomater.pdb" target="ref/netcoreapp3.1" />
+		<file src="net452\QuantConnect.IBAutomater.exe" target="lib/net452" />
+		<file src="net452\QuantConnect.IBAutomater.pdb" target="lib/net452" />
+		<file src="net452\QuantConnect.IBAutomater.exe" target="lib/netcoreapp3.1" />
+		<file src="net452\QuantConnect.IBAutomater.pdb" target="lib/netcoreapp3.1" />
+		<file src="QuantConnect.IBAutomater.targets" target="build" />
 		<file src="net452\IBAutomater.bat" target="build" />
 		<file src="net452\IBAutomater.sh" target="build" />
     <file src="IBAutomater.jar" target="build" />


### PR DESCRIPTION
second part to fix #15 

This changes the `nuspec` to output targets for both `.NET Framework 4.5.2` and `.NET Core 3.1`. Previously, the NuGet was not able to be used in `.NET Core` projects. This PR keeps changes to a minimum by:

- reusing the same output from the `net452` build for both targets, so that `QuantConnect.IBAutomater` only needs to be built once
- keeping the dependencies on `Newtonsoft.Json` at `10.0.3` and `NodaTime` at `1.3.4`, but now specifies them properly
- fixing warnings generated when the `nuget.exe pack` command is run




Other than this PR, there are two other ways to solve #15:

- change `QuantConnect.IBAutomater` to output a `dll` instead of an `exe`. Then, it will be able to target `.NET Standard 1.2`, which can be used from [both](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) `.NET Framework 4.5.1+` and `.NET Core 1.0+`
- move the `nuspec` contents to the `QuantConnect.IBAutomater.csproj`. And add `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>`. This will then generate the `NuGet `directly upon build of `QuantConnect.IBAutomater`, without having to do `nuget.exe pack`.

If either of these solutions sound better to you, I can submit a PR with it instead. 