### PR TITLE
Fix Linux script for weekly restarts

### DIFF
--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -277,14 +277,14 @@ namespace QuantConnect.IBAutomater
                 {
                     if (e.Data != null)
                     {
-                        OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs(e.Data));
+                        OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs(e.Data.Replace(_password, "***")));
                     }
                 };
                 process.ErrorDataReceived += (s, e) =>
                 {
                     if (e.Data != null)
                     {
-                        ErrorDataReceived?.Invoke(this, new ErrorDataReceivedEventArgs(e.Data));
+                        ErrorDataReceived?.Invoke(this, new ErrorDataReceivedEventArgs(e.Data.Replace(_password, "***")));
                     }
                 };
                 process.Exited += OnProcessExited;

--- a/QuantConnect.IBAutomater/IBAutomater.sh
+++ b/QuantConnect.IBAutomater/IBAutomater.sh
@@ -2,8 +2,10 @@
 
 ps -AFH
 
-pkill Xvfb
-pkill java
+pkill -9 Xvfb
+pkill -9 java
+
+sleep 5
 
 ps -AFH
 

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.32</Version>
+    <Version>2.0.33</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.30</Version>
+    <Version>2.0.32</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>


### PR DESCRIPTION
- Updated the Linux script to prevent the following error when restarting `Xvfb`:
```
(EE)
Fatal server error:
(EE) Server is already active for display 1
        If this server is no longer running, remove /tmp/.X1-lock
        and start again.
(EE)
```
- Updated the message handler to prevent logging the user password