### PR TITLE
Uncheck "Use Account Groups with Allocation Methods" config setting

### DIFF
--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.33</Version>
+    <Version>2.0.34</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -381,6 +381,16 @@ public class WindowEventListener implements AWTEventListener {
             createApiLog.setSelected(true);
         }
 
+        String faText = "Use Account Groups with Allocation Methods";
+        JCheckBox faCheckBox = Common.getCheckBox(window, faText);
+        if (faCheckBox == null) {
+            throw new Exception("'" + faText + "' check box not found");
+        }
+        if (faCheckBox.isSelected()) {
+            this.automater.logMessage("Unselect checkbox: [" + faText + "]");
+            faCheckBox.setSelected(false);
+        }
+
         Common.selectTreeNode(tree, new TreePath(new String[]{"Configuration", "API", "Precautions"}));
 
         String bypassOrderPrecautionsText = "Bypass Order Precautions for API Orders";


### PR DESCRIPTION
- Prevents existing clients calling the IB API method `requestFA(Profiles)` from receiving this error:
```
ErrorCode: 321 - Error validating request.-'ce' : cause - Non-existent FA data operation request.
```
- https://www.interactivebrokers.com/en/index.php?f=24356