### PR TITLE
Fix configuration for compatibility with IBGateway v978

### DIFF
--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.34</Version>
+    <Version>2.0.35</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -381,14 +381,14 @@ public class WindowEventListener implements AWTEventListener {
             createApiLog.setSelected(true);
         }
 
+        // v983+
         String faText = "Use Account Groups with Allocation Methods";
         JCheckBox faCheckBox = Common.getCheckBox(window, faText);
-        if (faCheckBox == null) {
-            throw new Exception("'" + faText + "' check box not found");
-        }
-        if (faCheckBox.isSelected()) {
-            this.automater.logMessage("Unselect checkbox: [" + faText + "]");
-            faCheckBox.setSelected(false);
+        if (faCheckBox != null) {
+            if (faCheckBox.isSelected()) {
+                this.automater.logMessage("Unselect checkbox: [" + faText + "]");
+                faCheckBox.setSelected(false);
+            }
         }
 
         Common.selectTreeNode(tree, new TreePath(new String[]{"Configuration", "API", "Precautions"}));


### PR DESCRIPTION
- The `"Use Account Groups with Allocation Methods"` checkbox is only present in the configuration window with IBGateway `v983+`: https://www.interactivebrokers.com/en/index.php?f=24356

- IBAutomater was throwing an error when running with v978 after #44 
