### PR TITLE
Add retry logic after 2FA timeout

### DIFF
--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.IBAutomater
     /// </summary>
     public class IBAutomater
     {
-        private readonly TimeSpan _initializationTimeout = TimeSpan.FromMinutes(10);
+        private readonly TimeSpan _initializationTimeout = TimeSpan.FromMinutes(15);
 
         private readonly string _ibDirectory;
         private readonly string _ibVersion;

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.41</Version>
+    <Version>2.0.42</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.42</Version>
+    <Version>2.0.43</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>


### PR DESCRIPTION
- After a 2FA timeout error at login time, IBAutomater will retry logging in two more times
- If both retries fail, the 2FA timeout error will be reported to the client application