### PR TITLE
Enable "Use SSL"

### DIFF
--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -804,7 +804,7 @@ namespace QuantConnect.IBAutomater
         private void LoadIbServerInformation()
         {
             // After a successful login, IBGateway saves the connected/redirected host name to the Peer key in the jts.ini file.
-            var iniFileName = Path.Combine(_ibDirectory, "jts.ini");
+            var iniFileName = GetIbGatewayIniFile();
 
             // Note: Attempting to connect to a different server via jts.ini will not change anything.
             // IB will route you back to the server they have set for you on their server side.
@@ -900,9 +900,14 @@ namespace QuantConnect.IBAutomater
             return ibGatewayVersionPath;
         }
 
+        private string GetIbGatewayIniFile()
+        {
+            return Path.Combine(IsWindows ? GetIbGatewayVersionPath() : _ibDirectory, "jts.ini");
+        }
+
         private void UpdateIbGatewayIniFile()
         {
-            var ibGatewayIniFile = Path.Combine(_ibDirectory, "jts.ini");
+            var ibGatewayIniFile = GetIbGatewayIniFile();
             OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs($"Updating IBGateway ini file: {ibGatewayIniFile}"));
 
             // The "Use SSL" checkbox in the IBGateway UX has inconsistent behavior,

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -224,6 +224,7 @@ namespace QuantConnect.IBAutomater
                     return new StartResult(ErrorCode.JavaNotFound);
                 }
 
+                UpdateIbGatewayIniFile();
                 UpdateIbGatewayConfiguration(ibGatewayVersionPath, true);
 
                 _timerLogReader.Change(Timeout.Infinite, Timeout.Infinite);
@@ -897,6 +898,28 @@ namespace QuantConnect.IBAutomater
             }
 
             return ibGatewayVersionPath;
+        }
+
+        private void UpdateIbGatewayIniFile()
+        {
+            var ibGatewayIniFile = Path.Combine(_ibDirectory, "jts.ini");
+            OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs($"Updating IBGateway ini file: {ibGatewayIniFile}"));
+
+            // The "Use SSL" checkbox in the IBGateway UX has inconsistent behavior,
+            // so we preset the "UseSSL=true" value in jts.ini
+            if (File.Exists(ibGatewayIniFile))
+            {
+                var iniText = File.ReadAllText(ibGatewayIniFile);
+                if (iniText.Contains("UseSSL=false"))
+                {
+                    iniText = iniText.Replace("UseSSL=false", "UseSSL=true");
+                    File.WriteAllText(ibGatewayIniFile, iniText);
+                }
+            }
+            else
+            {
+                File.WriteAllText(ibGatewayIniFile, $"[Logon]{Environment.NewLine}UseSSL=true");
+            }
         }
 
         private void UpdateIbGatewayConfiguration(string ibGatewayVersionPath, bool enableJavaAgent)

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.49</Version>
+    <Version>2.0.50</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.47</Version>
+    <Version>2.0.48</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.46</Version>
+    <Version>2.0.47</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.48</Version>
+    <Version>2.0.49</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -203,6 +203,18 @@ public class WindowEventListener implements AWTEventListener {
         }
         passwordTextField.setText(this.automater.getSettings().getPassword());
 
+        String useSslText = "Use SSL";
+        JCheckBox useSslCheckbox = Common.getCheckBox(window, useSslText);
+        if (useSslCheckbox == null) {
+            this.automater.logMessage("Use SSL checkbox not found");
+        }
+        else {
+            if (!useSslCheckbox.isSelected()) {
+                this.automater.logMessage("Select checkbox: [" + useSslText + "]");
+                useSslCheckbox.setSelected(true);
+            }
+        }
+
         String loginButtonText = isLiveTradingMode ? "Log In" : "Paper Log In";
         JButton loginButton = Common.getButton(window, loginButtonText);
         if (loginButton == null) {

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -139,6 +139,9 @@ public class WindowEventListener implements AWTEventListener {
             if (this.HandleDisplayMarketDataWindow(window, eventId)) {
                 return;
             }
+            if (this.HandleUseSslEncryptionWindow(window, eventId)) {
+                return;
+            }
 
             HandleUnknownMessageWindow(window, eventId);
         }
@@ -751,6 +754,28 @@ public class WindowEventListener implements AWTEventListener {
         return false;
     }
 
+    private boolean HandleUseSslEncryptionWindow(Window window, int eventId) {
+        if (eventId != WindowEvent.WINDOW_OPENED) {
+            return false;
+        }
+
+        String title = Common.getTitle(window);
+
+        if (title != null && title.contains("Use SSL encryption")) {
+
+            String buttonText = "Reconnect using SSL";
+            JButton button = Common.getButton(window, buttonText);
+            if (button != null) {
+                this.automater.logMessage("Click button: [" + buttonText + "]");
+                button.doClick();
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
     private boolean IsKnownWindowTitle(String title) {
         if (title.equals("Second Factor Authentication") ||
             title.equals("Security Code Card Authentication") ||
@@ -938,6 +963,18 @@ public class WindowEventListener implements AWTEventListener {
             else if (component instanceof JTextPane)
             {
                 text = " - Text: [" + ((JTextPane) component).getText() + "]";
+            }
+            else if (component instanceof JTextField)
+            {
+                text = " - Text: [" + ((JTextField) component).getText() + "]";
+            }
+            else if (component instanceof JCheckBox)
+            {
+                text = " - Text: [" + ((JCheckBox) component).getText() + "]";
+            }
+            else if (component instanceof JOptionPane)
+            {
+                text = " - Message: [" + ((JOptionPane) component).getMessage().toString() + "]";
             }
             this.automater.logMessage("DEBUG: - Component: [" + component.toString() + "]" + text);
         });


### PR DESCRIPTION
- The "Use SSL" logon setting is now always set to true.
- Some users were not able to logon without this setting, this error window was displayed after entering their credentials:

![image](https://user-images.githubusercontent.com/7236689/129566085-8c8b2730-f24b-4e34-8a2a-374127841268.png)
