### PR TITLE
Protection and recovery from disconnection issues

### DIFF
--- a/CSharpDemoIBAutomater/Program.cs
+++ b/CSharpDemoIBAutomater/Program.cs
@@ -31,7 +31,7 @@ namespace CSharpDemoIBAutomater
             var ibPort = 4002;
 
             // Create a new instance of the IBAutomater class
-            var automater = new IBAutomater(ibDirectory, ibVersion, ibUserName, ibPassword, ibTradingMode, ibPort, false);
+            using var automater = new IBAutomater(ibDirectory, ibVersion, ibUserName, ibPassword, ibTradingMode, ibPort, false);
 
             // Attach the event handlers
             automater.OutputDataReceived += (s, e) => Console.WriteLine($"{DateTime.UtcNow:O} {e.Data}");

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.69</Version>
+    <Version>2.0.70</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/QuantConnect.IBAutomater/StartResult.cs
+++ b/QuantConnect.IBAutomater/StartResult.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.IBAutomater
         UnknownMessageWindowDetected,
 
         /// <summary>
-        /// The IBGateway soft restart timed out but will be automatically triggered again
+        /// The IBGateway soft restart timed out
         /// </summary>
         SoftRestartTimeout
     }
@@ -164,7 +164,7 @@ namespace QuantConnect.IBAutomater
                 },
                 {
                     ErrorCode.SoftRestartTimeout,
-                    "The IBGateway soft restart timed out but will be automatically triggered again."
+                    "The IBGateway soft restart timed out."
                 }
             };
 

--- a/QuantConnect.IBAutomater/StartResult.cs
+++ b/QuantConnect.IBAutomater/StartResult.cs
@@ -90,7 +90,12 @@ namespace QuantConnect.IBAutomater
         /// <summary>
         /// An unknown IB message window was detected
         /// </summary>
-        UnknownMessageWindowDetected
+        UnknownMessageWindowDetected,
+
+        /// <summary>
+        /// The IBGateway soft restart timed out but will be automatically triggered again
+        /// </summary>
+        SoftRestartTimeout
     }
 
     /// <summary>
@@ -156,6 +161,10 @@ namespace QuantConnect.IBAutomater
                 {
                     ErrorCode.UnknownMessageWindowDetected,
                     "An unknown IB message window was detected."
+                },
+                {
+                    ErrorCode.SoftRestartTimeout,
+                    "The IBGateway soft restart timed out but will be automatically triggered again."
                 }
             };
 

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -442,6 +442,8 @@ public class WindowEventListener implements AWTEventListener {
 
             RunInitializationUsingThread();
             RunRestartWatcher();
+
+            return true;
         }
 
         return false;


### PR DESCRIPTION
- Spacing consecutive gateway restarts by increasing the delay in a period of 1 hour in order to reduce the number of consecutive restarts.
- Recovering from timed-out restarts by trying again one more time or sending an error.
