### PR TITLE
Failed restart event communication

### DIFF
--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -839,7 +839,7 @@ namespace QuantConnect.IBAutomater
         /// Returns whether the IBGateway is running
         /// </summary>
         /// <returns>true if the IBGateway is running</returns>
-        private bool IsRunning()
+        public bool IsRunning()
         {
             lock (_locker)
             {

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -560,7 +560,10 @@ namespace QuantConnect.IBAutomater
                 {
                     TraceIbLauncherLogFile();
 
-                    _lastStartResult = new StartResult(ErrorCode.InitializationTimeout);
+                    _lastStartResult = new StartResult(ErrorCode.InitializationTimeout, "Auto-restart timed out");
+
+                    // fire Exited event so the client can reconnect or die
+                    Exited?.Invoke(this, new ExitedEventArgs(0));
                     return;
                 }
 
@@ -577,7 +580,10 @@ namespace QuantConnect.IBAutomater
 
                         TraceIbLauncherLogFile();
 
-                        _lastStartResult = new StartResult(ErrorCode.RestartedProcessNotFound);
+                        _lastStartResult = new StartResult(ErrorCode.RestartedProcessNotFound, "IBGateway process was not found after restart");
+
+                        // fire Exited event so the client can reconnect or die
+                        Exited?.Invoke(this, new ExitedEventArgs(0));
                     }
                     else
                     {

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.76</Version>
+    <Version>2.0.77</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>


### PR DESCRIPTION
- Communicate failed restart events back to the consumer through the `Exited` event handler.
- Make `IsRunning` public so consumers can ask whether the gateway is up and running.