### PR TITLE
Improve gateway shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,4 +331,5 @@ ASALocalRun/
 /java/IBAutomater/nbproject/private/
 /java/IBAutomater/build/
 /java/IBAutomater/dist/
+/java/IBAutomater/out/
 *.jar

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -641,7 +641,7 @@ namespace QuantConnect.IBAutomater
                 // then we wait for the process to exit.
                 // we'll wait 10 seconds, since it will take up to 1 second for the java automater to receive the signal
                 // plus a 9 second buffer for the gateway to exit.
-                if (!_process.WaitForExit(20000))
+                if (!_process.WaitForExit(10000))
                 {
                     // if the process does not exit after a timeout, then we kill it
                     if (IsWindows)

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -639,10 +639,13 @@ namespace QuantConnect.IBAutomater
                 StopGatewayRestartTimeoutMonitor();
 
                 // then we wait for the process to exit.
-                // we'll wait 10 seconds, since it will take up to 1 second for the java automater to receive the signal
-                // plus a 9 second buffer for the gateway to exit.
-                if (!_process.WaitForExit(10000))
+                // we'll wait 15 seconds, since it will take up to 1 second for the java automater to receive the signal
+                // plus a 14 second buffer for the gateway to exit.
+                if (!_process.WaitForExit(15000))
                 {
+                    OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs(
+                        "Timeout waiting for the IBAutomater to shutdown the IB Gateway. Proceeding to kill the process."));
+
                     // if the process does not exit after a timeout, then we kill it
                     if (IsWindows)
                     {

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -631,40 +631,54 @@ namespace QuantConnect.IBAutomater
 
                 _timerLogReader.Change(Timeout.Infinite, Timeout.Infinite);
 
-                if (IsWindows)
+                var ibGatewayVersionPath = GetIbGatewayVersionPath();
+                var shutdownFilePath = Path.Combine(ibGatewayVersionPath, "shutdown");
+                File.WriteAllBytes(shutdownFilePath, Array.Empty<byte>());
+
+                // stop any restart threads
+                StopGatewayRestartTimeoutMonitor();
+
+                // then we wait for the process to exit.
+                // we'll wait 20 seconds, since it will take up to 10 seconds for the java automater to receive the signal
+                // plus a 10 second buffer for the gateway to exit
+                if (!_process.WaitForExit(20000))
                 {
-                    foreach (var process in Process.GetProcesses())
+                    // if the process does not exit after a timeout, then we kill it
+                    if (IsWindows)
+                    {
+                        foreach (var process in Process.GetProcesses())
+                        {
+                            try
+                            {
+                                if (process.MainWindowTitle.ToLower().Contains("gateway"))
+                                {
+                                    process.Kill();
+                                }
+                            }
+                            catch (Exception)
+                            {
+                                // ignored
+                            }
+                        }
+                    }
+                    else
                     {
                         try
                         {
-                            if (process.MainWindowTitle.ToLower().Contains("gateway"))
-                            {
-                                process.Kill();
-                            }
+                            Process.Start("pkill", "java");
+                            Process.Start("pkill", "Xvfb");
                         }
                         catch (Exception)
                         {
                             // ignored
                         }
                     }
-                }
-                else
-                {
-                    try
-                    {
-                        Process.Start("pkill", "java");
-                        Process.Start("pkill", "Xvfb");
-                    }
-                    catch (Exception)
-                    {
-                        // ignored
-                    }
+
+                    // wait for the process to exit
+                    _process.WaitForExit();
                 }
 
                 _process = null;
-
-                // stop any restart threads
-                StopGatewayRestartTimeoutMonitor();
             }
         }
 
@@ -759,37 +773,37 @@ namespace QuantConnect.IBAutomater
                 switch (_ibServerRegion)
                 {
                     case Region.Europe:
-                    {
-                        // Saturday - Thursday: 05:45 - 06:45 CET
-                        var euTime = utcTime.ConvertFromUtc(TimeZoneZurich);
-                        var euTimeOfDay = euTime.TimeOfDay;
-                        result = euTimeOfDay > new TimeSpan(5, 30, 0) && euTimeOfDay < new TimeSpan(7, 0, 0);
-                    }
+                        {
+                            // Saturday - Thursday: 05:45 - 06:45 CET
+                            var euTime = utcTime.ConvertFromUtc(TimeZoneZurich);
+                            var euTimeOfDay = euTime.TimeOfDay;
+                            result = euTimeOfDay > new TimeSpan(5, 30, 0) && euTimeOfDay < new TimeSpan(7, 0, 0);
+                        }
                         break;
 
                     case Region.Asia:
-                    {
-                        // Saturday - Thursday: First reset: 16:30 - 17:00 ET
-                        if (newYorkTimeOfDay > new TimeSpan(16, 15, 0) && newYorkTimeOfDay < new TimeSpan(17, 15, 0))
                         {
-                            result = true;
+                            // Saturday - Thursday: First reset: 16:30 - 17:00 ET
+                            if (newYorkTimeOfDay > new TimeSpan(16, 15, 0) && newYorkTimeOfDay < new TimeSpan(17, 15, 0))
+                            {
+                                result = true;
+                            }
+                            else
+                            {
+                                // Saturday - Thursday: Second reset: 20:15 - 21:00 HKT
+                                var hkTime = utcTime.ConvertFromUtc(TimeZoneHongKong);
+                                var hkTimeOfDay = hkTime.TimeOfDay;
+                                result = hkTimeOfDay > new TimeSpan(20, 0, 0) && hkTimeOfDay < new TimeSpan(21, 15, 0);
+                            }
                         }
-                        else
-                        {
-                            // Saturday - Thursday: Second reset: 20:15 - 21:00 HKT
-                            var hkTime = utcTime.ConvertFromUtc(TimeZoneHongKong);
-                            var hkTimeOfDay = hkTime.TimeOfDay;
-                            result = hkTimeOfDay > new TimeSpan(20, 0, 0) && hkTimeOfDay < new TimeSpan(21, 15, 0);
-                        }
-                    }
                         break;
 
                     case Region.America:
                     default:
-                    {
-                        // Saturday - Thursday: 23:45 - 00:45 ET
-                        result = newYorkTimeOfDay > new TimeSpan(23, 30, 0) || newYorkTimeOfDay < new TimeSpan(1, 0, 0);
-                    }
+                        {
+                            // Saturday - Thursday: 23:45 - 00:45 ET
+                            result = newYorkTimeOfDay > new TimeSpan(23, 30, 0) || newYorkTimeOfDay < new TimeSpan(1, 0, 0);
+                        }
                         break;
                 }
             }
@@ -1253,7 +1267,7 @@ namespace QuantConnect.IBAutomater
         {
             if (e.Data != null)
             {
-                if(e.Data.Contains("JAVA_TOOL_OPTIONS"))
+                if (e.Data.Contains("JAVA_TOOL_OPTIONS"))
                 {
                     // this is not an error
                     SendTraceLog(sender, e);

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -639,9 +639,9 @@ namespace QuantConnect.IBAutomater
                 StopGatewayRestartTimeoutMonitor();
 
                 // then we wait for the process to exit.
-                // we'll wait 20 seconds, since it will take up to 10 seconds for the java automater to receive the signal
-                // plus a 10 second buffer for the gateway to exit
-                if (!_process.WaitForExit(20000))
+                // we'll wait 10 seconds, since it will take up to 1 second for the java automater to receive the signal
+                // plus a 9 second buffer for the gateway to exit.
+                if (!_process.WaitForExit(10))
                 {
                     // if the process does not exit after a timeout, then we kill it
                     if (IsWindows)

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -641,7 +641,7 @@ namespace QuantConnect.IBAutomater
                 // then we wait for the process to exit.
                 // we'll wait 10 seconds, since it will take up to 1 second for the java automater to receive the signal
                 // plus a 9 second buffer for the gateway to exit.
-                if (!_process.WaitForExit(10))
+                if (!_process.WaitForExit(20000))
                 {
                     // if the process does not exit after a timeout, then we kill it
                     if (IsWindows)

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.77</Version>
+    <Version>2.0.78</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/java/IBAutomater/src/ibautomater/ShutdownTask.java
+++ b/java/IBAutomater/src/ibautomater/ShutdownTask.java
@@ -1,0 +1,66 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * IBAutomater v1.0. Copyright 2019 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package ibautomater;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.concurrent.Callable;
+
+/**
+ * Handles the task of finding the IBGateway main window and shutting it down
+ *
+ * @author QuantConnect Corporation
+ */
+public class ShutdownTask implements Callable<Window> {
+    private final IBAutomater automater;
+
+    /**
+     * Creates a new instance of the {@link ShutdownTask} class.
+     *
+     * @param automater The {@link IBAutomater} instance
+     */
+    ShutdownTask(IBAutomater automater) {
+
+        this.automater = automater;
+    }
+
+    /**
+     * Returns the IBGateway main window, or throws an exception if unable to do so.
+     *
+     * @return Returns the IBGateway main window
+     */
+    @Override
+    @SuppressWarnings("SleepWhileInLoop")
+    public Window call() throws Exception {
+        while (true) {
+            this.automater.logMessage("Finding main window...");
+
+            for (Window w : Window.getWindows()) {
+                JMenuItem menuItem = Common.getMenuItem(w, "File", "Close");
+                if (menuItem != null) {
+                    this.automater.logMessage("Found main window (Window title: [" + Common.getTitle(w) + "] - Window name: [" + w.getName() + "])");
+                    menuItem.doClick();
+
+                    return w;
+                }
+            }
+
+            this.automater.logMessage("Main window not found.");
+
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -529,7 +529,7 @@ public class WindowEventListener implements AWTEventListener {
                         break;
                     }
 
-                    Thread.sleep(1000 * 10);
+                    Thread.sleep(1000);
                 } catch (InterruptedException ex) {
                     // stopped
                 }

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -445,6 +445,7 @@ public class WindowEventListener implements AWTEventListener {
 
             RunInitializationUsingThread();
             RunRestartWatcher();
+            RunShutdownWatcher();
 
             return true;
         }
@@ -485,6 +486,47 @@ public class WindowEventListener implements AWTEventListener {
                         this.automater.logMessage("Restart request detected, starting restart...");
                         this.restartNow = true;
                         RunInitializationUsingThread();
+                    }
+
+                    Thread.sleep(1000 * 10);
+                } catch (InterruptedException ex) {
+                    // stopped
+                }
+            }
+        }).start();
+    }
+
+    /**
+     * Will start a thread which will get the main window and trigger shutdown
+     */
+    private void RunShutdownUsingThread() {
+        new Thread(()-> {
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            Future<Window> future = executor.submit(new ShutdownTask(this.automater));
+            try {
+                future.get(30, TimeUnit.SECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                this.automater.logError(e);
+            }
+            executor.shutdown();
+        }).start();
+    }
+
+    /**
+     * Will start a thread which will monitor for and trigger shutdown
+     */
+    @SuppressWarnings("SleepWhileInLoop")
+    private void RunShutdownWatcher() {
+        new Thread(()-> {
+            this.automater.logMessage("Start running shutdown watcher thread...");
+            while (true) {
+                try {
+                    File file = new File("shutdown");
+                    if (file.exists()) {
+                        file.delete();
+                        this.automater.logMessage("Shutdown request detected. Shutting down...");
+                        RunShutdownUsingThread();
+                        break;
                     }
 
                     Thread.sleep(1000 * 10);


### PR DESCRIPTION
- Using a file to signal shutdown to the java agent, like we do for the soft restart.
- As for the soft restart, a thread in the Java agent polls this file and triggers shutdown by explicitly clicking on the Gateways's `File -> Close` menu item.

Note: wasn't able to reproduce the issue neither in the cloud nor locally. 
- In the cloud, tried deploying an algorithm that throws and checking the automatic re-deployment option.
- In a local environment inside a container a bash script was used to deploy an algorithm that throws an exception (in Initialize and in OnData) and re-deploy it N times to check whether any of those re-deployments failed trying to connect to IB, but it always connected without issue. Nevertheless, this PR would be a good prevention measure for this bug.

Close https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/issues/91