### PR TITLE
Fix bug `IBAutomater.sh` not found

### DIFF
--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -221,6 +221,12 @@ namespace QuantConnect.IBAutomater
         {
             lock (_locker)
             {
+                var ibAutomaterPath = "IBAutomater.sh";
+                if (!File.Exists(ibAutomaterPath))
+                {
+                    ibAutomaterPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), ibAutomaterPath);
+                }
+
                 if (_lastStartResult.HasError)
                 {
                     // IBAutomater errors are unrecoverable
@@ -239,7 +245,7 @@ namespace QuantConnect.IBAutomater
                 {
                     // need permission for execution
                     OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs("Setting execute permissions on IBAutomater.sh"));
-                    ExecuteProcessAndWaitForExit("chmod", "+x IBAutomater.sh");
+                    ExecuteProcessAndWaitForExit("chmod", $"+x {ibAutomaterPath}");
                 }
 
                 var ibGatewayVersionPath = GetIbGatewayVersionPath();
@@ -283,7 +289,7 @@ namespace QuantConnect.IBAutomater
                 }
                 else
                 {
-                    fileName = "IBAutomater.sh";
+                    fileName = ibAutomaterPath;
                     arguments = $"{ibGatewayVersionPath} {javaAgent}";
                 }
 

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.79</Version>
+    <Version>2.0.80</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>


### PR DESCRIPTION
Sometimes, `IBAutomater.sh` is not in the working directory. In those cases, we find the directory dynamically using the Dll currently being executed.