### PR TITLE
Upgrade IB Gateway version

### DIFF
--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -313,7 +313,6 @@ namespace QuantConnect.IBAutomater
                 else
                 {
                     fileName = ibAutomaterPath;
-                    OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs($"\n\n -----> PROGRAM PATH: {ibGatewayVersionPath}"));
                     arguments = $"{ibGatewayExecutablePath} {javaAgent} {arguments}";
                 }
 
@@ -331,11 +330,6 @@ namespace QuantConnect.IBAutomater
                         var sessionFolderName = Directory.GetParent(autoRestartFilePath).Name;
                         arguments += $" -J-DCHANNEL=stable -J-DchannelChanged=false -J-Drestart={sessionFolderName}";
                     }
-                }
-
-                if (IsWindows)
-                {
-                    OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs($"LAUNCHING IB GATEWAY {fileName}"));
                 }
 
                 var process = new Process
@@ -388,8 +382,6 @@ namespace QuantConnect.IBAutomater
                     if (_ibAutomaterInitializeEvent.WaitOne(_initializationTimeout))
                     {
                         var processName = IsWindows ? Path.GetFileNameWithoutExtension(fileName) : "java";
-                        OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs($"TRYING TPO FIND PROCESS BY NAME {processName}"));
-
                         var p = Process.GetProcessesByName(processName).FirstOrDefault();
                         OutputDataReceived?.Invoke(this,
                             p != null

--- a/QuantConnect.IBAutomater/IBAutomater.sh
+++ b/QuantConnect.IBAutomater/IBAutomater.sh
@@ -17,6 +17,6 @@ Xvfb :1 -screen 0 1024x768x24 2>&1 >/dev/null &
 export DISPLAY=:1
 
 ibgatewayExecutable=$1
-shift 2
+shift
 
 $ibgatewayExecutable "$@"

--- a/QuantConnect.IBAutomater/IBAutomater.sh
+++ b/QuantConnect.IBAutomater/IBAutomater.sh
@@ -9,8 +9,14 @@ pkill -9 java
 
 sleep 5
 
+rm /tmp/.X1-lock
 ps -AFH
 
+unset DISPLAY
 Xvfb :1 -screen 0 1024x768x24 2>&1 >/dev/null &
 export DISPLAY=:1
-$1/ibgateway
+
+ibgatewayExecutable=$1
+shift 2
+
+$ibgatewayExecutable "$@"

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.81</Version>
+    <Version>2.0.82</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/java/IBAutomater/src/ibautomater/IBAutomater.java
+++ b/java/IBAutomater/src/ibautomater/IBAutomater.java
@@ -50,8 +50,9 @@ public final class IBAutomater {
         String tradingMode = argValues[2];
         int portNumber = Integer.parseInt(argValues[3]);
         boolean exportIbGatewayLogs = Boolean.parseBoolean(argValues[4]);
+        boolean restarting = Boolean.parseBoolean(argValues[5]);
 
-        IBAutomater automater = new IBAutomater(userName, password, tradingMode, portNumber, exportIbGatewayLogs);
+        IBAutomater automater = new IBAutomater(userName, password, tradingMode, portNumber, exportIbGatewayLogs, restarting);
     }
 
     /**
@@ -63,9 +64,11 @@ public final class IBAutomater {
      * @param portNumber The socket port number to be used for API connections
      * @param exportIbGatewayLogs If true, IBGateway logs will be exported at predefined times
      * (currently at startup and when unknown windows are detected)
+     * @param restarting If true, the automater will assume the gateway is starting after a 
+     * soft daily restart and won't try to log in
      */
-    public IBAutomater(String userName, String password, String tradingMode, int portNumber, boolean exportIbGatewayLogs) {
-        this.settings = new Settings(userName, password, tradingMode, portNumber, exportIbGatewayLogs);
+    public IBAutomater(String userName, String password, String tradingMode, int portNumber, boolean exportIbGatewayLogs, boolean restarting) {
+        this.settings = new Settings(userName, password, tradingMode, portNumber, exportIbGatewayLogs, restarting);
 
         try
         {

--- a/java/IBAutomater/src/ibautomater/Settings.java
+++ b/java/IBAutomater/src/ibautomater/Settings.java
@@ -26,6 +26,7 @@ public class Settings {
     private final String tradingMode;
     private final int portNumber;
     private final boolean exportIbGatewayLogs;
+    private final boolean restarting;
 
     /**
      * Creates a new instance of the {@link Settings} class.
@@ -36,13 +37,16 @@ public class Settings {
      * @param portNumber The socket port number to be used for API connections
      * @param exportIbGatewayLogs If true, IBGateway logs will be exported at predefined times
      * (currently at startup and when unknown windows are detected)
+     * @param restarting If true, the automater will assume the gateway is starting after a 
+     * soft daily restart and won't try to log in
      */
-    public Settings(String userName, String password, String tradingMode, int portNumber, boolean exportIbGatewayLogs) {
+    public Settings(String userName, String password, String tradingMode, int portNumber, boolean exportIbGatewayLogs, boolean restarting) {
         this.userName = userName;
         this.password = password;
         this.tradingMode = tradingMode;
         this.portNumber = portNumber;
         this.exportIbGatewayLogs = exportIbGatewayLogs;
+        this.restarting = restarting;
     }
 
     /**
@@ -88,6 +92,15 @@ public class Settings {
      */
     public boolean getExportIbGatewayLogs() {
         return this.exportIbGatewayLogs;
+    }
+
+    /**
+     * Gets whether IBGateway is starting after a soft daily restart
+     *
+     * @return Returns true if IBGateway is starting after a soft daily restart
+     */
+    public boolean getRestarting() {
+        return this.restarting;
     }
 }
 

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -193,7 +193,9 @@ public class WindowEventListener implements AWTEventListener {
      * @return Returns true if the window was detected and handled
      */
     private boolean HandleLoginWindow(Window window, int eventId) throws Exception {
-        if (eventId != WindowEvent.WINDOW_OPENED) {
+        if (eventId != WindowEvent.WINDOW_OPENED || 
+            // restarting, no need to manually log in
+            this.automater.getSettings().getRestarting()) {
             return false;
         }
 


### PR DESCRIPTION
Fixes for IB Gateway version upgrade to 10.30.
Manually triggering soft restart to ensure automater is attached to the gateway process.

Part of https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/issues/143
Related https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/pull/145 https://github.com/QuantConnect/Lean/pull/8586 https://github.com/QuantConnect/LeanCloud/pull/1243