### PR TITLE
Uncheck 'Use Account Groups with Allocation Methods'

### DIFF
--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net9.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.84</Version>
+    <Version>2.0.85</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -714,9 +714,9 @@ public class WindowEventListener implements AWTEventListener {
         // v983+
         String faText = "Use Account Groups with Allocation Methods";
         JCheckBox faCheckBox = Common.getCheckBox(window, faText);
-        if (faCheckBox != null && !faCheckBox.isSelected()) {
-            this.automater.logMessage("Select checkbox: [" + faText + "]");
-            faCheckBox.setSelected(true);
+        if (faCheckBox != null && faCheckBox.isSelected()) {
+            this.automater.logMessage("Unselect checkbox: [" + faText + "]");
+            faCheckBox.setSelected(false);
         }
 
         Common.selectTreeNode(tree, new TreePath(new String[]{"Configuration", "API", "Precautions"}));


### PR DESCRIPTION
- Uncheck 'Use Account Groups with Allocation Methods', which avoids order properties from being able to specify the allocation method for FA accounts