### PR TITLE
Handle order confirmation windows and select all API order precaution bypasses

### DIFF
--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net10.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.89</Version>
+    <Version>2.0.90</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -1338,8 +1338,15 @@ public class WindowEventListener implements AWTEventListener {
     }
 
     /**
-     * Detects and handles the order confirmation windows
-     * ("Market Order Confirmation", "Cash Quantity Order Warning").
+     * Detects and handles the order confirmation/warning windows.
+     * These windows share the same layout: a message, a
+     * "Don't display this message again." check box and an
+     * "Accept and Continue" button (e.g. "Market Order Confirmation",
+     * "Cash Quantity Order Warning"). The window is detected by the
+     * presence of the "Accept and Continue" button rather than by its
+     * title, so any such confirmation window is handled.
+     * - reads the message shown to the user and logs it so the brokerage
+     *   can surface it to the user as a message
      * - selects the "Don't display this message again." check box
      * - clicks the "Accept and Continue" button
      *
@@ -1353,18 +1360,25 @@ public class WindowEventListener implements AWTEventListener {
             return false;
         }
 
-        String title = Common.getTitle(window);
-
-        if (title == null ||
-            (!title.contains("Market Order Confirmation") &&
-             !title.contains("Cash Quantity Order Warning"))) {
+        String buttonText = "Accept and Continue";
+        JButton button = Common.getButton(window, buttonText);
+        if (button == null) {
+            // not an order confirmation window
             return false;
         }
+
+        String title = Common.getTitle(window);
+        String content = GetWindowText(window).replaceAll("\\s+", " ").trim();
+        String message = (title != null && !title.isEmpty() ? title + ": " : "") + content;
+
+        // the brokerage surfaces this line to the user as a BrokerageMessage
+        this.automater.logMessage("Order confirmation window: " + message);
 
         String checkBoxText = "Don't display this message again.";
         JCheckBox checkBox = Common.getCheckBox(window, checkBoxText);
         if (checkBox == null) {
-            checkBox = Common.getCheckBox(window, "Don't display this message again");
+            // try without the trailing period
+            checkBox = Common.getCheckBox(window, checkBoxText.substring(0, checkBoxText.length() - 1));
         }
         if (checkBox != null) {
             if (!checkBox.isSelected()) {
@@ -1376,16 +1390,8 @@ public class WindowEventListener implements AWTEventListener {
             this.automater.logMessage("Checkbox not found: [" + checkBoxText + "]");
         }
 
-        String buttonText = "Accept and Continue";
-        JButton button = Common.getButton(window, buttonText);
-
-        if (button != null) {
-            this.automater.logMessage("Click button: [" + buttonText + "]");
-            button.doClick();
-        }
-        else {
-            throw new Exception("Button not found: [" + buttonText + "]");
-        }
+        this.automater.logMessage("Click button: [" + buttonText + "]");
+        button.doClick();
 
         return true;
     }

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -50,7 +50,6 @@ import javax.swing.JToggleButton;
 import javax.swing.JTree;
 import javax.swing.ListModel;
 import javax.swing.SwingUtilities;
-import javax.swing.Timer;
 import javax.swing.tree.TreePath;
 
 /**
@@ -904,10 +903,7 @@ public class WindowEventListener implements AWTEventListener {
 
     /**
      * Detects and handles the Financial Advisor warning window.
-     * - logs the window contents
-     * - selects the "Don't display this message again." check box if present
-     * - clicks the confirmation button ("Accept and Continue", "OK", "Transmit" or "Yes")
-     * - verifies the window was closed by the click
+     * - clicks the "Yes" button
      *
      * @param window The window instance
      * @param eventId The id of the window event
@@ -922,51 +918,16 @@ public class WindowEventListener implements AWTEventListener {
         String title = Common.getTitle(window);
 
         if (title != null && title.contains("Financial Advisor Warning")) {
-            LogWindowContents(window);
+            String buttonText = "Yes";
+            JButton button = Common.getButton(window, buttonText);
 
-            // newer gateway versions gate the confirmation button behind this check box
-            for (Component component : Common.getComponents(window)) {
-                if (component instanceof JCheckBox) {
-                    JCheckBox checkBox = (JCheckBox)component;
-                    String checkBoxText = checkBox.getText();
-                    if (checkBoxText != null
-                        && checkBoxText.toLowerCase().contains("display this message")
-                        && !checkBox.isSelected()) {
-                        this.automater.logMessage("Select checkbox: [" + checkBoxText + "]");
-                        checkBox.setSelected(true);
-                    }
-                }
+            if (button != null) {
+                this.automater.logMessage("Click button: [" + buttonText + "]");
+                button.doClick();
             }
-
-            JButton button = null;
-            String buttonText = null;
-            for (String text : new String[] { "Accept and Continue", "OK", "Transmit", "Yes" }) {
-                button = Common.getButton(window, text);
-                if (button != null) {
-                    buttonText = text;
-                    break;
-                }
+            else {
+                throw new Exception("Button not found: [" + buttonText + "]");
             }
-
-            if (button == null) {
-                throw new Exception("Button not found: [Yes]");
-            }
-
-            this.automater.logMessage("Click button: [" + buttonText + "] - Enabled: [" + button.isEnabled() + "]");
-            button.doClick();
-
-            // the click on a disabled button is a silent no-op,
-            // so verify the window was actually closed
-            final String clickedButtonText = buttonText;
-            Timer timer = new Timer(2000, (event) -> {
-                if (window.isDisplayable()) {
-                    this.automater.logMessage("Financial Advisor Warning window still open after clicking [" + clickedButtonText + "]");
-                    LogWindowContents(window);
-                    SaveIBLogs();
-                }
-            });
-            timer.setRepeats(false);
-            timer.start();
 
             return true;
         }

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -174,7 +174,7 @@ public class WindowEventListener implements AWTEventListener {
             if (this.HandleUseSslEncryptionWindow(window, eventId)) {
                 return;
             }
-            if (this.HandleMarketOrderConfirmationWindow(window, eventId)) {
+            if (this.HandleOrderConfirmationWindow(window, eventId)) {
                 return;
             }
             if (this.HandleLoginMessages(window, eventId)) {
@@ -1338,7 +1338,8 @@ public class WindowEventListener implements AWTEventListener {
     }
 
     /**
-     * Detects and handles the Market Order Confirmation window.
+     * Detects and handles the order confirmation windows
+     * ("Market Order Confirmation", "Cash Quantity Order Warning").
      * - selects the "Don't display this message again." check box
      * - clicks the "Accept and Continue" button
      *
@@ -1347,14 +1348,16 @@ public class WindowEventListener implements AWTEventListener {
      *
      * @return Returns true if the window was detected and handled
      */
-    private boolean HandleMarketOrderConfirmationWindow(Window window, int eventId) throws Exception {
+    private boolean HandleOrderConfirmationWindow(Window window, int eventId) throws Exception {
         if (eventId != WindowEvent.WINDOW_OPENED) {
             return false;
         }
 
         String title = Common.getTitle(window);
 
-        if (title == null || !title.contains("Market Order Confirmation")) {
+        if (title == null ||
+            (!title.contains("Market Order Confirmation") &&
+             !title.contains("Cash Quantity Order Warning"))) {
             return false;
         }
 

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -732,9 +732,21 @@ public class WindowEventListener implements AWTEventListener {
         if (bypassOrderPrecautions == null) {
             throw new Exception("Bypass Order Precautions check box not found");
         }
-        if (!bypassOrderPrecautions.isSelected()) {
-            this.automater.logMessage("Select checkbox: [" + bypassOrderPrecautionsText + "]");
-            bypassOrderPrecautions.setSelected(true);
+
+        // Select every "Bypass ... for API Orders" precaution check box so that order
+        // confirmation/warning dialogs are not shown for API orders. Enabling only the main
+        // "Bypass Order Precautions for API Orders" is not enough (e.g. Financial Advisor
+        // accounts still get warnings), so we select all of them. The Precautions panel is
+        // the only configuration panel with "Bypass"-prefixed check boxes.
+        for (Component component : Common.getComponents(window)) {
+            if (component instanceof JCheckBox) {
+                JCheckBox checkBox = (JCheckBox) component;
+                String checkBoxText = checkBox.getText();
+                if (checkBoxText != null && checkBoxText.startsWith("Bypass") && !checkBox.isSelected()) {
+                    this.automater.logMessage("Select checkbox: [" + checkBoxText + "]");
+                    checkBox.setSelected(true);
+                }
+            }
         }
 
         Common.selectTreeNode(tree, new TreePath(new String[]{"Configuration", "Lock and Exit"}));

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -1458,10 +1458,17 @@ public class WindowEventListener implements AWTEventListener {
             return false;
         }
 
-        String title = Common.getTitle(window);
         String windowName = window.getName();
+        if (windowName == null) {
+            return false;
+        }
 
-        if (windowName != null && windowName.startsWith("dialog") && !IsKnownWindowTitle(title))
+        String title = Common.getTitle(window);
+        if (IsKnownWindowTitle(title)) {
+            return false;
+        }
+
+        if (windowName.startsWith("dialog"))
         {
             LogWindowContents(window);
 
@@ -1479,9 +1486,7 @@ public class WindowEventListener implements AWTEventListener {
         // newer gateway versions name their windows "IBKR Gateway" instead of "dialogN",
         // so dump their contents for diagnostics, without emitting the
         // "Unknown message window detected" error marker
-        if (windowName != null && windowName.equals("IBKR Gateway")
-            && window != this.automater.getMainWindow()
-            && !IsKnownWindowTitle(title))
+        if (windowName.equals("IBKR Gateway") && window != this.automater.getMainWindow())
         {
             LogWindowContents(window);
 

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -50,6 +50,7 @@ import javax.swing.JToggleButton;
 import javax.swing.JTree;
 import javax.swing.ListModel;
 import javax.swing.SwingUtilities;
+import javax.swing.Timer;
 import javax.swing.tree.TreePath;
 
 /**
@@ -891,7 +892,10 @@ public class WindowEventListener implements AWTEventListener {
 
     /**
      * Detects and handles the Financial Advisor warning window.
-     * - clicks the "Yes" button
+     * - logs the window contents
+     * - selects the "Don't display this message again." check box if present
+     * - clicks the confirmation button ("Accept and Continue", "OK", "Transmit" or "Yes")
+     * - verifies the window was closed by the click
      *
      * @param window The window instance
      * @param eventId The id of the window event
@@ -906,16 +910,51 @@ public class WindowEventListener implements AWTEventListener {
         String title = Common.getTitle(window);
 
         if (title != null && title.contains("Financial Advisor Warning")) {
-            String buttonText = "Yes";
-            JButton button = Common.getButton(window, buttonText);
+            LogWindowContents(window);
 
-            if (button != null) {
-                this.automater.logMessage("Click button: [" + buttonText + "]");
-                button.doClick();
+            // newer gateway versions gate the confirmation button behind this check box
+            for (Component component : Common.getComponents(window)) {
+                if (component instanceof JCheckBox) {
+                    JCheckBox checkBox = (JCheckBox)component;
+                    String checkBoxText = checkBox.getText();
+                    if (checkBoxText != null
+                        && checkBoxText.toLowerCase().contains("display this message")
+                        && !checkBox.isSelected()) {
+                        this.automater.logMessage("Select checkbox: [" + checkBoxText + "]");
+                        checkBox.setSelected(true);
+                    }
+                }
             }
-            else {
-                throw new Exception("Button not found: [" + buttonText + "]");
+
+            JButton button = null;
+            String buttonText = null;
+            for (String text : new String[] { "Accept and Continue", "OK", "Transmit", "Yes" }) {
+                button = Common.getButton(window, text);
+                if (button != null) {
+                    buttonText = text;
+                    break;
+                }
             }
+
+            if (button == null) {
+                throw new Exception("Button not found: [Yes]");
+            }
+
+            this.automater.logMessage("Click button: [" + buttonText + "] - Enabled: [" + button.isEnabled() + "]");
+            button.doClick();
+
+            // the click on a disabled button is a silent no-op,
+            // so verify the window was actually closed
+            final String clickedButtonText = buttonText;
+            Timer timer = new Timer(2000, (event) -> {
+                if (window.isDisplayable()) {
+                    this.automater.logMessage("Financial Advisor Warning window still open after clicking [" + clickedButtonText + "]");
+                    LogWindowContents(window);
+                    SaveIBLogs();
+                }
+            });
+            timer.setRepeats(false);
+            timer.start();
 
             return true;
         }
@@ -1434,6 +1473,20 @@ public class WindowEventListener implements AWTEventListener {
             return true;
         }
 
+        // newer gateway versions name their windows "IBKR Gateway" instead of "dialogN",
+        // so dump their contents for diagnostics, without emitting the
+        // "Unknown message window detected" error marker
+        if (windowName != null && windowName.equals("IBKR Gateway")
+            && window != this.automater.getMainWindow()
+            && !IsKnownWindowTitle(title))
+        {
+            LogWindowContents(window);
+
+            this.automater.logMessage("Unhandled window detected - Window title: [" + title + "]");
+
+            return true;
+        }
+
         return false;
     }
 
@@ -1614,7 +1667,13 @@ public class WindowEventListener implements AWTEventListener {
             }
             else if (component instanceof JCheckBox)
             {
-                text = " - JCheckBox Text: [" + ((JCheckBox) component).getText() + "]";
+                JCheckBox checkBox = (JCheckBox) component;
+                text = " - JCheckBox Text: [" + checkBox.getText() + "] - Selected: [" + checkBox.isSelected() + "] - Enabled: [" + checkBox.isEnabled() + "]";
+            }
+            else if (component instanceof JButton)
+            {
+                JButton button = (JButton) component;
+                text = " - JButton Text: [" + button.getText() + "] - Enabled: [" + button.isEnabled() + "]";
             }
             else if (component instanceof JOptionPane)
             {

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -173,6 +173,9 @@ public class WindowEventListener implements AWTEventListener {
             if (this.HandleUseSslEncryptionWindow(window, eventId)) {
                 return;
             }
+            if (this.HandleMarketOrderConfirmationWindow(window, eventId)) {
+                return;
+            }
             if (this.HandleLoginMessages(window, eventId)) {
                 return;
             }
@@ -1293,6 +1296,56 @@ public class WindowEventListener implements AWTEventListener {
         }
 
         return false;
+    }
+
+    /**
+     * Detects and handles the Market Order Confirmation window.
+     * - selects the "Don't display this message again." check box
+     * - clicks the "Accept and Continue" button
+     *
+     * @param window The window instance
+     * @param eventId The id of the window event
+     *
+     * @return Returns true if the window was detected and handled
+     */
+    private boolean HandleMarketOrderConfirmationWindow(Window window, int eventId) throws Exception {
+        if (eventId != WindowEvent.WINDOW_OPENED) {
+            return false;
+        }
+
+        String title = Common.getTitle(window);
+
+        if (title == null || !title.contains("Market Order Confirmation")) {
+            return false;
+        }
+
+        String checkBoxText = "Don't display this message again.";
+        JCheckBox checkBox = Common.getCheckBox(window, checkBoxText);
+        if (checkBox == null) {
+            checkBox = Common.getCheckBox(window, "Don't display this message again");
+        }
+        if (checkBox != null) {
+            if (!checkBox.isSelected()) {
+                this.automater.logMessage("Select checkbox: [" + checkBoxText + "]");
+                checkBox.setSelected(true);
+            }
+        }
+        else {
+            this.automater.logMessage("Checkbox not found: [" + checkBoxText + "]");
+        }
+
+        String buttonText = "Accept and Continue";
+        JButton button = Common.getButton(window, buttonText);
+
+        if (button != null) {
+            this.automater.logMessage("Click button: [" + buttonText + "]");
+            button.doClick();
+        }
+        else {
+            throw new Exception("Button not found: [" + buttonText + "]");
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
- Select **all** "Bypass ... for API Orders" check boxes in the API/Precautions configuration panel (not just "Bypass Order Precautions for API Orders"). Verified across 10 FA-account syslogs that the single bypass was already enabled yet the Financial Advisor Warning still fired and blocked orders, so we now enable every precaution bypass.
- Handles the new IB Gateway order confirmation windows ("Market Order Confirmation", "Cash Quantity Order Warning"):
  - Detects them by their "Accept and Continue" button (title-independent), so any confirmation window sharing that layout is covered
  - Selects the "Don't display this message again." check box
  - Clicks the "Accept and Continue" button
  - Reads the dialog message and logs it so the brokerage can surface it to the user as a BrokerageMessage
- Dumps the contents of unknown windows named "IBKR Gateway" for diagnostics (new gateway windows are not named "dialogN", so they bypassed the unknown-window diagnostics; the dump does not emit the "Unknown message window detected" error marker)
- Logs the enabled state of buttons and the selected/enabled state of check boxes in the window content dumps
- Bumps version to 2.0.90

The "Financial Advisor Warning" handler is left unchanged. An earlier revision of this branch reworked it on the theory that it was behind QuantConnect/Lean.Brokerages.InteractiveBrokers#93, but the log analysis on that issue attributes the timeouts to IB-side causes (dropped placement requests, out-of-hours cancellations acknowledged after the timeout window, and error 460 not invalidating the order), not to a dialog. That rework has been reverted.

| Market Order Confirmation | Cash Quantity Order Warning |
|---|---|
| ![Market Order Confirmation window](https://raw.githubusercontent.com/AlexCatarino/IBAutomater/pr-assets/market-order-confirmation.jpeg) | ![Cash Quantity Order Warning window](https://raw.githubusercontent.com/AlexCatarino/IBAutomater/pr-assets/cash-quantity-order-warning.jpeg) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
