### PR TITLE
Log Financial Advisor Warning window contents for diagnostics

### DIFF
--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net10.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.90</Version>
+    <Version>2.0.91</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -741,7 +741,11 @@ public class WindowEventListener implements AWTEventListener {
             if (component instanceof JCheckBox) {
                 JCheckBox checkBox = (JCheckBox) component;
                 String checkBoxText = checkBox.getText();
-                if (checkBoxText != null && checkBoxText.startsWith("Bypass") && !checkBox.isSelected()) {
+                if (checkBoxText == null) {
+                    continue;
+                }
+                this.automater.logMessage("Checkbox: [" + checkBoxText + "] - Selected: [" + checkBox.isSelected() + "]");
+                if (checkBoxText.startsWith("Bypass") && !checkBox.isSelected()) {
                     this.automater.logMessage("Select checkbox: [" + checkBoxText + "]");
                     checkBox.setSelected(true);
                 }

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -949,7 +949,14 @@ public class WindowEventListener implements AWTEventListener {
 
                     if (window.isDisplayable()) {
                         this.automater.logMessage("Error: Financial Advisor Warning window still open after clicking [" + buttonText + "], the order will not be transmitted");
-                        SwingUtilities.invokeLater(() -> LogWindowContents(window));
+                        // an exception here would be uncaught on the EDT, eventDispatched cannot cover this path
+                        SwingUtilities.invokeLater(() -> {
+                            try {
+                                LogWindowContents(window);
+                            } catch (Exception e) {
+                                this.automater.logError(e);
+                            }
+                        });
                     }
                 }).start();
             }
@@ -1492,8 +1499,12 @@ public class WindowEventListener implements AWTEventListener {
 
         // newer gateway versions name their windows "IBKR Gateway" instead of "dialogN",
         // so dump the contents of any unhandled window regardless of its name,
-        // without emitting the "Unknown message window detected" error marker
-        if (window != this.automater.getMainWindow())
+        // without emitting the "Unknown message window detected" error marker.
+        // The main window cannot be excluded by identity alone: its WINDOW_OPENED event can
+        // arrive before it is registered, so we also skip any window with the File/Close menu
+        // (the main window fingerprint, cf. ShutdownTask) to avoid dumping the whole frame
+        if (window != this.automater.getMainWindow()
+            && Common.getMenuItem(window, "File", "Close") == null)
         {
             LogWindowContents(window);
 
@@ -1692,7 +1703,8 @@ public class WindowEventListener implements AWTEventListener {
             }
             else if (component instanceof JOptionPane)
             {
-                text = " - JOptionPane Message: [" + ((JOptionPane) component).getMessage().toString() + "]";
+                // getMessage() can be null, which would abort the whole dump mid-window
+                text = " - JOptionPane Message: [" + String.valueOf(((JOptionPane) component).getMessage()) + "]";
             }
             this.automater.logMessage("DEBUG: - Component: [" + component.toString() + "]" + text);
         });

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -903,6 +903,7 @@ public class WindowEventListener implements AWTEventListener {
 
     /**
      * Detects and handles the Financial Advisor warning window.
+     * - logs the window structure
      * - clicks the "Yes" button
      *
      * @param window The window instance
@@ -918,10 +919,17 @@ public class WindowEventListener implements AWTEventListener {
         String title = Common.getTitle(window);
 
         if (title != null && title.contains("Financial Advisor Warning")) {
+            
+            LogWindowContents(window);
+
             String buttonText = "Yes";
             JButton button = Common.getButton(window, buttonText);
 
             if (button != null) {
+                if (!button.isEnabled()) {
+                    // doClick() on a disabled button is a silent no-op
+                    this.automater.logMessage("Error: Financial Advisor Warning window: the [" + buttonText + "] button is disabled.");
+                }
                 this.automater.logMessage("Click button: [" + buttonText + "]");
                 button.doClick();
             }
@@ -1463,9 +1471,9 @@ public class WindowEventListener implements AWTEventListener {
         }
 
         // newer gateway versions name their windows "IBKR Gateway" instead of "dialogN",
-        // so dump their contents for diagnostics, without emitting the
-        // "Unknown message window detected" error marker
-        if (windowName.equals("IBKR Gateway") && window != this.automater.getMainWindow())
+        // so dump the contents of any unhandled window regardless of its name,
+        // without emitting the "Unknown message window detected" error marker
+        if (window != this.automater.getMainWindow())
         {
             LogWindowContents(window);
 

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -909,6 +909,7 @@ public class WindowEventListener implements AWTEventListener {
      * Detects and handles the Financial Advisor warning window.
      * - logs the window structure
      * - clicks the "Yes" button
+     * - checks whether the window closed after the click
      *
      * @param window The window instance
      * @param eventId The id of the window event
@@ -936,6 +937,21 @@ public class WindowEventListener implements AWTEventListener {
                 }
                 this.automater.logMessage("Click button: [" + buttonText + "]");
                 button.doClick();
+
+                // The flagged order is not transmitted until this window closes,
+                // so check whether the click was effective
+                new Thread(()-> {
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        return;
+                    }
+
+                    if (window.isDisplayable()) {
+                        this.automater.logMessage("Error: Financial Advisor Warning window still open after clicking [" + buttonText + "], the order will not be transmitted");
+                        SwingUtilities.invokeLater(() -> LogWindowContents(window));
+                    }
+                }).start();
             }
             else {
                 throw new Exception("Button not found: [" + buttonText + "]");


### PR DESCRIPTION
## Problem

IB Gateway opens a "Financial Advisor Warning" dialog when (some) FA group orders are submitted via the API. `HandleFinancialAdvisorWarningWindow` matches it, clicks "Yes" and reports the window as handled — but the flagged orders are never transmitted: no `orderStatus`, no `execDetails`, no error, ever, and the algorithm times out 5 minutes later with `Timeout waiting for brokerage response` (QuantConnect/Lean.Brokerages.InteractiveBrokers#93 — 16 incidents across 4 distinct advisors, recurring daily).

Nobody knows what the dialog says: no screenshot exists, the 2019 handler predates the gateway redesign, and the diagnostics that would have captured its contents were gated off (the unknown-window dump requires a `dialogN`/`IBKR Gateway` window name, and the FA handler returns "handled" before reaching it anyway).

## Change (diagnostics-only)

- **Check whether the window closed one second after clicking "Yes"** — if still open, log an error and dump the window contents again. Syslog analysis shows the windows open in a rapid burst (one per order) and the lost orders are always exactly the ones in flight during the burst (a consecutive broker id band, regardless of instrument), so this check discriminates whether the click is lost (window stays open) or lands and the order is dropped server-side. Retry logic is deliberately deferred until the failure mode is confirmed.
- **Log the full window structure** (message text, every button and check box with its enabled/selected state) before clicking "Yes", so the next occurrence tells us exactly what the dialog says and which control transmits.
- **Log an error when the "Yes" button is disabled** — `doClick()` on a disabled button is a silent no-op (a likely failure mode: the redesigned dialogs gate the confirm button behind a "Don''t display this message again." check box, cf. #104). The button is still clicked regardless, exactly as before.
- **Log every configuration check box with its selected state** while handling the configuration window, capturing the API Precautions panel options — including any Financial Advisor specific precaution not prefixed with "Bypass".
- **Widen the unknown-window diagnostic**: dump the contents of any unhandled window regardless of its window name.
- Bump version to 2.0.91.

Once a new incident captures the dialog contents, a follow-up PR will implement the actual fix (select the gating check box, click the correct confirmation button).

Related to QuantConnect/Lean.Brokerages.InteractiveBrokers#93 (complements the brokerage-side mitigation in QuantConnect/Lean.Brokerages.InteractiveBrokers#240)

🤖 Generated with [Claude Code](https://claude.com/claude-code)





