### PR TITLE
Ensure the gateway exits when it is expected to close itself

### DIFF
--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -665,6 +665,13 @@ namespace QuantConnect.IBAutomater
                 }
                 else
                 {
+                    // The restarted gateway is expected to close itself shortly (e.g. weekly restart
+                    // with an expired auto-restart token). If it fails to do so, it would be left
+                    // running but unauthenticated, and the client would skip the cold start (with
+                    // full authentication) seeing the gateway is still running.
+                    // So we make sure it is actually stopped before reporting the exit.
+                    EnsureGatewayIsStopped();
+
                     Exited?.Invoke(this, new ExitedEventArgs(GetProcessExitCode(_process)));
                 }
             }
@@ -673,6 +680,39 @@ namespace QuantConnect.IBAutomater
                 // Let's rename the gateway program back to its original name
                 RenameIbGatewayProgram(true);
                 Exited?.Invoke(this, new ExitedEventArgs(GetProcessExitCode(_process)));
+            }
+        }
+
+        /// <summary>
+        /// Ensures the gateway process is not left running when it is expected to have closed itself,
+        /// so the client can safely perform a cold start (with full authentication) afterwards.
+        /// </summary>
+        private void EnsureGatewayIsStopped()
+        {
+            try
+            {
+                var process = _process;
+                if (process == null || process.HasExited)
+                {
+                    return;
+                }
+
+                // give the gateway some time to close itself gracefully,
+                // the java agent will force an exit if closing the main window fails
+                if (process.WaitForExit(90000))
+                {
+                    return;
+                }
+
+                OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs(
+                    "IBGateway was expected to close but is still running, stopping it."));
+
+                Stop();
+            }
+            catch (Exception exception)
+            {
+                OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs(
+                    $"EnsureGatewayIsStopped(): error stopping the gateway: {exception.Message}"));
             }
         }
 

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -697,8 +697,10 @@ namespace QuantConnect.IBAutomater
                     return;
                 }
 
-                // give the gateway some time to close itself gracefully,
-                // the java agent will force an exit if closing the main window fails
+                // give the gateway some time to close itself gracefully: the java agent waits
+                // up to ~30s for the close to execute and force-exits the process ~30s later
+                // (~60s worst case), so waiting 90s leaves slack for that fallback to land
+                // before we take over and stop it ourselves
                 if (process.WaitForExit(90000))
                 {
                     return;
@@ -706,6 +708,11 @@ namespace QuantConnect.IBAutomater
 
                 OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs(
                     "IBGateway was expected to close but is still running, stopping it."));
+
+                // Stop() kills the process, which would fire OnProcessExited a second time for
+                // this same gateway death; our caller is already reporting the exit, so we
+                // unsubscribe from this handle to avoid two competing restarts on the client
+                process.Exited -= OnProcessExited;
 
                 Stop();
             }

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -650,6 +650,12 @@ namespace QuantConnect.IBAutomater
 
                     _lastStartResult = new StartResult(ErrorCode.InitializationTimeout, "Auto-restart timed out");
 
+                    // the relaunched gateway may still be running (e.g. the token-expired dialog
+                    // text changed and fell through to an unknown-window error, or initialization
+                    // timed out): make sure it is stopped before reporting the exit, otherwise the
+                    // client would see it running and skip the cold start (with full authentication)
+                    EnsureGatewayIsStopped();
+
                     // fire Exited event so the client can reconnect or die
                     Exited?.Invoke(this, new ExitedEventArgs(0));
                     return;

--- a/java/IBAutomater/src/ibautomater/Common.java
+++ b/java/IBAutomater/src/ibautomater/Common.java
@@ -210,7 +210,10 @@ public class Common {
      * @return Returns a JMenuItem instance in the given container with the specified text, null if the menu item is not found
      */
     public static JMenuItem getMenuItem(Container container, String menuText, String menuItemText) {
-        if (container == null) return null;
+        // Callers pass arbitrary windows (e.g. scanning Window.getWindows() for the main window,
+        // or inspecting unknown dialogs), so guard the cast: only a JFrame carries a menu bar,
+        // anything else (a JDialog, a bare Window) simply has no menu item to find
+        if (!(container instanceof JFrame)) return null;
         JMenuBar menuBar = ((JFrame) container).getJMenuBar();
         if (menuBar == null) return null;
         for (int i = 0; i < menuBar.getMenuCount(); ++i) {

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -1606,7 +1606,7 @@ public class WindowEventListener implements AWTEventListener {
                     // the "auto-restart token expired" dialog can open before the new main window
                     // is registered, so we find it like ShutdownTask does instead of failing
                     // with a null reference and leaving the gateway running
-                    while (mainWindow == null) {
+                    for (int attempt = 0; mainWindow == null && attempt < 20; attempt++) {
                         this.automater.logMessage("Main window not found, waiting...");
                         Thread.sleep(1000);
 
@@ -1616,6 +1616,11 @@ public class WindowEventListener implements AWTEventListener {
                                 break;
                             }
                         }
+                    }
+
+                    if (mainWindow == null) {
+                        this.automater.logMessage("Main window not found, giving up");
+                        return;
                     }
 
                     this.automater.logMessage("Closing main window - Window title: [" + Common.getTitle(mainWindow) + "] - Window name: [" + mainWindow.getName() + "]");
@@ -1641,16 +1646,33 @@ public class WindowEventListener implements AWTEventListener {
 
             // Every caller needs the gateway process to exit: the client waits for the process
             // exit to perform a cold start with full authentication, so a gateway left running
-            // here would stay alive but unauthenticated. If we are still running after the
-            // close attempt, we exit the process as a last resort.
+            // here would stay alive but unauthenticated. If the close did not complete after the
+            // wait below, we exit the process as a last resort.
+            // Note the client waits 90 seconds for this process to exit before stopping it
+            // externally, so this fallback (~60s worst case) must stay well within that budget.
             try {
                 Thread.sleep(30000);
             } catch (InterruptedException e) {
                 // ignored
             }
 
-            this.automater.logMessage("IBGateway did not close after CloseMainWindow, exiting the process");
-            System.exit(0);
+            // A window that is still displayable means the close did not complete. We cannot rely
+            // on getMainWindow() here (it can be unregistered in the very scenario above), and a
+            // slow but succeeding close has already disposed its windows, so we leave it alone.
+            boolean isAnyWindowDisplayable = false;
+            for (Window window : Window.getWindows()) {
+                if (window.isDisplayable()) {
+                    isAnyWindowDisplayable = true;
+                    break;
+                }
+            }
+
+            if (isAnyWindowDisplayable) {
+                this.automater.logMessage("IBGateway did not close after CloseMainWindow, exiting the process");
+                System.exit(0);
+            }
+
+            this.automater.logMessage("CloseMainWindow thread ended");
 
         }).start();
     }

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -1590,6 +1590,7 @@ public class WindowEventListener implements AWTEventListener {
     /**
      * Closes the main window.
      */
+    @SuppressWarnings("SleepWhileInLoop")
     private void CloseMainWindow()
     {
         new Thread(()-> {
@@ -1600,15 +1601,34 @@ public class WindowEventListener implements AWTEventListener {
             executor.execute(() -> {
                 try {
                     Window mainWindow = this.automater.getMainWindow();
+
+                    // The main window can still be unknown at this point, e.g. after an auto-restart
+                    // the "auto-restart token expired" dialog can open before the new main window
+                    // is registered, so we find it like ShutdownTask does instead of failing
+                    // with a null reference and leaving the gateway running
+                    while (mainWindow == null) {
+                        this.automater.logMessage("Main window not found, waiting...");
+                        Thread.sleep(1000);
+
+                        for (Window window : Window.getWindows()) {
+                            if (Common.getMenuItem(window, "File", "Close") != null) {
+                                mainWindow = window;
+                                break;
+                            }
+                        }
+                    }
+
                     this.automater.logMessage("Closing main window - Window title: [" + Common.getTitle(mainWindow) + "] - Window name: [" + mainWindow.getName() + "]");
-                    ((JFrame) this.automater.getMainWindow()).setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-                    WindowEvent closingEvent = new WindowEvent(this.automater.getMainWindow(), WindowEvent.WINDOW_CLOSING);
+                    ((JFrame) mainWindow).setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                    WindowEvent closingEvent = new WindowEvent(mainWindow, WindowEvent.WINDOW_CLOSING);
                     Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(closingEvent);
                     this.automater.logMessage("Close main window message sent");
                 } catch (Exception e) {
                     this.automater.logMessage("CloseMainWindow execute error: " + e.getMessage());
                 }
             });
+
+            executor.shutdown();
 
             try {
                 if (!executor.awaitTermination(30, TimeUnit.SECONDS))
@@ -1619,7 +1639,18 @@ public class WindowEventListener implements AWTEventListener {
                 this.automater.logMessage("CloseMainWindow await error: " + e.getMessage());
             }
 
-            this.automater.logMessage("CloseMainWindow thread ended");
+            // Every caller needs the gateway process to exit: the client waits for the process
+            // exit to perform a cold start with full authentication, so a gateway left running
+            // here would stay alive but unauthenticated. If we are still running after the
+            // close attempt, we exit the process as a last resort.
+            try {
+                Thread.sleep(30000);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+
+            this.automater.logMessage("IBGateway did not close after CloseMainWindow, exiting the process");
+            System.exit(0);
 
         }).start();
     }

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -1646,33 +1646,40 @@ public class WindowEventListener implements AWTEventListener {
 
             // Every caller needs the gateway process to exit: the client waits for the process
             // exit to perform a cold start with full authentication, so a gateway left running
-            // here would stay alive but unauthenticated. If the close did not complete after the
-            // wait below, we exit the process as a last resort.
+            // here would stay alive but unauthenticated. If the close does not complete within
+            // the grace period below, we exit the process as a last resort.
+            //
+            // Give the close time to take effect, but stop as soon as it has: a window that is
+            // still displayable means the close did not complete, while a succeeding close has
+            // already disposed its windows. We poll rather than sleeping a flat interval so the
+            // happy path returns promptly instead of holding the JVM alive on this non-daemon
+            // thread for the whole period. We cannot rely on getMainWindow() here (it can be
+            // unregistered in the very scenario above), hence the displayable-window check.
             // Note the client waits 90 seconds for this process to exit before stopping it
-            // externally, so this fallback (~60s worst case) must stay well within that budget.
+            // externally, so this fallback (~30s worst case) must stay well within that budget.
             try {
-                Thread.sleep(30000);
+                for (int attempt = 0; attempt < 30; attempt++) {
+                    Thread.sleep(1000);
+
+                    boolean isAnyWindowDisplayable = false;
+                    for (Window window : Window.getWindows()) {
+                        if (window.isDisplayable()) {
+                            isAnyWindowDisplayable = true;
+                            break;
+                        }
+                    }
+
+                    if (!isAnyWindowDisplayable) {
+                        this.automater.logMessage("CloseMainWindow thread ended");
+                        return;
+                    }
+                }
             } catch (InterruptedException e) {
                 // ignored
             }
 
-            // A window that is still displayable means the close did not complete. We cannot rely
-            // on getMainWindow() here (it can be unregistered in the very scenario above), and a
-            // slow but succeeding close has already disposed its windows, so we leave it alone.
-            boolean isAnyWindowDisplayable = false;
-            for (Window window : Window.getWindows()) {
-                if (window.isDisplayable()) {
-                    isAnyWindowDisplayable = true;
-                    break;
-                }
-            }
-
-            if (isAnyWindowDisplayable) {
-                this.automater.logMessage("IBGateway did not close after CloseMainWindow, exiting the process");
-                System.exit(0);
-            }
-
-            this.automater.logMessage("CloseMainWindow thread ended");
+            this.automater.logMessage("IBGateway did not close after CloseMainWindow, exiting the process");
+            System.exit(0);
 
         }).start();
     }


### PR DESCRIPTION
## Problem

Root-cause fix for the IBAutomater side of QuantConnect/Lean.Brokerages.InteractiveBrokers#246.

During the Sunday nightly restart, IB expires the auto-restart token and the java agent must close the relaunched gateway so the client performs a cold start with full authentication (2FA). The "auto-restart token expired" dialog can open before the new main window is registered, so `CloseMainWindow` failed with:

```
CloseMainWindow execute error: Cannot invoke "java.awt.Window.getName()" because "mainWindow" is null
```

The exception is caught and only logged, so the gateway was left running but **unauthenticated**. The client had already fired `Exited` (exit code 0, by design on this path), and when its delayed restart later ran, `IsRunning()` returned true, so the cold start — the only path that triggers the weekly 2FA push — was skipped. Result: a permanently disconnected brokerage that ran silently for days (two deployments, 2026-07-26 and 2026-08-02).

## Fix

**Java agent (`WindowEventListener.java`)**
- If `getMainWindow()` is null, find the main window the same way `ShutdownTask` does (scan `Window.getWindows()` for the `File/Close` menu) instead of failing.
- If the gateway is still alive ~30s after the close attempt, `System.exit(0)` as a last resort. Every `CloseMainWindow` caller (server disconnected, too many failed login attempts, token expired) requires the process to terminate — the client relies on the process exit to restart with a full login.
- Call `executor.shutdown()` before `awaitTermination` so the 30s "Timeout in execution of CloseMainWindow" no longer always fires even on success.

**C# client (`IBAutomater.cs`)**
- The `Exited` event fired on the token-expired path promises "the gateway is no longer running" while the relaunched process may still be alive. `EnsureGatewayIsStopped()` now waits up to 90s for the gateway to close itself (covering the java agent's forced-exit fallback) and calls `Stop()` (graceful shutdown file, then kill) if it does not — so `IsRunning()` can no longer report an unauthenticated leftover gateway after `Exited` was raised.
- This also avoids a latent `InvalidOperationException` on Windows where `GetProcessExitCode` would read `ExitCode` from a still-running process.

## Testing

- `QuantConnect.IBAutomater` builds clean (0 warnings / 0 errors).
- Java change is compile-verified by CI (no local JDK); it reuses the existing `ShutdownTask` window-discovery pattern.
- Reproduction scenario from the issue: weekly restart configured at 23:59 UTC → Sunday token-expiry exit at ~23:45 → previously left a zombie gateway; with this change the process is guaranteed dead before `Exited` is reported, so the delayed restart performs the cold start and requests 2FA.

Note: the engine-side hardening from the issue (weekly-restart skip keying off last authentication instead of last exit, and verifying connectivity instead of `IsRunning()` in the delayed restart) is complementary and remains for Lean.Brokerages.InteractiveBrokers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)