### PR TITLE
Configure IB Gateway FA allocation group mode - Feature 112 fav2

### DIFF
--- a/CSharpDemoIBAutomater/Program.cs
+++ b/CSharpDemoIBAutomater/Program.cs
@@ -29,7 +29,7 @@ namespace CSharpDemoIBAutomater
             var ibPassword = "mypassword";
             var ibTradingMode = "paper";
             var ibPort = 4002;
-            var preserveAccountGroupsWithAllocationMethods = false;
+            var useAccountGroupsWithAllocationMethods = false;
 
             // Create a new instance of the IBAutomater class
             using var automater = new IBAutomater(
@@ -40,7 +40,7 @@ namespace CSharpDemoIBAutomater
                 ibTradingMode,
                 ibPort,
                 false,
-                preserveAccountGroupsWithAllocationMethods);
+                useAccountGroupsWithAllocationMethods);
 
             // Attach the event handlers
             automater.OutputDataReceived += (s, e) => Console.WriteLine($"{DateTime.UtcNow:O} {e.Data}");

--- a/CSharpDemoIBAutomater/Program.cs
+++ b/CSharpDemoIBAutomater/Program.cs
@@ -29,9 +29,18 @@ namespace CSharpDemoIBAutomater
             var ibPassword = "mypassword";
             var ibTradingMode = "paper";
             var ibPort = 4002;
+            var preserveAccountGroupsWithAllocationMethods = false;
 
             // Create a new instance of the IBAutomater class
-            using var automater = new IBAutomater(ibDirectory, ibVersion, ibUserName, ibPassword, ibTradingMode, ibPort, false);
+            using var automater = new IBAutomater(
+                ibDirectory,
+                ibVersion,
+                ibUserName,
+                ibPassword,
+                ibTradingMode,
+                ibPort,
+                false,
+                preserveAccountGroupsWithAllocationMethods);
 
             // Attach the event handlers
             automater.OutputDataReceived += (s, e) => Console.WriteLine($"{DateTime.UtcNow:O} {e.Data}");

--- a/IBAutomater.sln
+++ b/IBAutomater.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.IBAutomater", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpDemoIBAutomater", "CSharpDemoIBAutomater\CSharpDemoIBAutomater.csproj", "{0C0C75BE-C651-4DC7-9F9B-C2971B9C1716}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuantConnect.IBAutomater.Tests", "QuantConnect.IBAutomater.Tests\QuantConnect.IBAutomater.Tests.csproj", "{60529C73-65BA-44AA-A11E-1F092438307D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{0C0C75BE-C651-4DC7-9F9B-C2971B9C1716}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C0C75BE-C651-4DC7-9F9B-C2971B9C1716}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C0C75BE-C651-4DC7-9F9B-C2971B9C1716}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60529C73-65BA-44AA-A11E-1F092438307D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60529C73-65BA-44AA-A11E-1F092438307D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60529C73-65BA-44AA-A11E-1F092438307D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60529C73-65BA-44AA-A11E-1F092438307D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/QuantConnect.IBAutomater.Tests/FinancialAdvisorConfigurationTests.cs
+++ b/QuantConnect.IBAutomater.Tests/FinancialAdvisorConfigurationTests.cs
@@ -1,0 +1,59 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * IBAutomater v1.0. Copyright 2019 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using NUnit.Framework;
+
+namespace QuantConnect.IBAutomater.Tests
+{
+    [TestFixture]
+    public class FinancialAdvisorConfigurationTests
+    {
+        [Test]
+        public void PreservesFinancialAdvisorErrorCodeValue()
+        {
+            Assert.That((int)ErrorCode.FinancialAdvisorAllocationGroupsConfigurationUnavailable, Is.EqualTo(16));
+        }
+
+        [Test]
+        public void PreservesOriginalPublicConstructor()
+        {
+            Assert.That(
+                typeof(IBAutomater).GetConstructor(new[]
+                {
+                    typeof(string),
+                    typeof(string),
+                    typeof(string),
+                    typeof(string),
+                    typeof(string),
+                    typeof(int),
+                    typeof(bool)
+                }),
+                Is.Not.Null);
+        }
+
+        [Test]
+        public void DescribesFinancialAdvisorDesiredStateFailure()
+        {
+            var result = new StartResult(ErrorCode.FinancialAdvisorAllocationGroupsConfigurationUnavailable);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ErrorMessage, Does.Contain("requested Use Account Groups with Allocation Methods setting"));
+                Assert.That(result.ErrorMessage, Does.Contain("could not be applied or verified"));
+            });
+        }
+    }
+}

--- a/QuantConnect.IBAutomater.Tests/QuantConnect.IBAutomater.Tests.csproj
+++ b/QuantConnect.IBAutomater.Tests/QuantConnect.IBAutomater.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\QuantConnect.IBAutomater\QuantConnect.IBAutomater.csproj" />
+  </ItemGroup>
+</Project>

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -41,7 +41,7 @@ namespace QuantConnect.IBAutomater
         private readonly string _tradingMode;
         private readonly int _portNumber;
         private readonly bool _exportIbGatewayLogs;
-        private readonly bool _preserveAccountGroupsWithAllocationMethods;
+        private readonly bool _useAccountGroupsWithAllocationMethods;
 
         private volatile bool _isDisposeCalled;
 
@@ -94,6 +94,8 @@ namespace QuantConnect.IBAutomater
         private CancellationTokenSource _gatewaySoftRestartTokenSource;
 
         private const string _ibGatewayExecutableOriginalName = "ibgateway";
+        private const string FinancialAdvisorAllocationGroupsConfigurationUnavailableMarker =
+            "Error: Financial Advisor allocation groups configuration unavailable:";
         private readonly string _ibGatewayExecutableName = $"{_ibGatewayExecutableOriginalName}1";
         private bool _renamedIbGatewayExcecutable;
 
@@ -136,10 +138,10 @@ namespace QuantConnect.IBAutomater
                 ibVersion = config["ib-version"].ToString();
             }
             var exportIbGatewayLogs = config["ib-export-ibgateway-logs"].ToObject<bool>();
-            var preserveAccountGroupsWithAllocationMethods = false;
+            var useAccountGroupsWithAllocationMethods = false;
             if (config["ib-financial-advisors-unified-groups-enabled"] != null)
             {
-                preserveAccountGroupsWithAllocationMethods =
+                useAccountGroupsWithAllocationMethods =
                     config["ib-financial-advisors-unified-groups-enabled"].ToObject<bool>();
             }
 
@@ -152,7 +154,7 @@ namespace QuantConnect.IBAutomater
                 tradingMode,
                 portNumber,
                 exportIbGatewayLogs,
-                preserveAccountGroupsWithAllocationMethods);
+                useAccountGroupsWithAllocationMethods);
 
             // Attach the event handlers
             automater.OutputDataReceived += (s, e) => Console.WriteLine($"{DateTime.UtcNow:O} {e.Data}");
@@ -210,8 +212,8 @@ namespace QuantConnect.IBAutomater
         /// <param name="tradingMode">The trading mode ('paper' or 'live')</param>
         /// <param name="portNumber">The API port number</param>
         /// <param name="exportIbGatewayLogs">Export IB Gateway logs if true</param>
-        /// <param name="preserveAccountGroupsWithAllocationMethods">
-        /// Leave the Use Account Groups with Allocation Methods setting unchanged if true
+        /// <param name="useAccountGroupsWithAllocationMethods">
+        /// Enable the Use Account Groups with Allocation Methods setting if true
         /// </param>
         public IBAutomater(
             string ibDirectory,
@@ -221,7 +223,7 @@ namespace QuantConnect.IBAutomater
             string tradingMode,
             int portNumber,
             bool exportIbGatewayLogs,
-            bool preserveAccountGroupsWithAllocationMethods)
+            bool useAccountGroupsWithAllocationMethods)
         {
             _ibDirectory = ibDirectory;
             _ibVersion = ibVersion;
@@ -230,7 +232,7 @@ namespace QuantConnect.IBAutomater
             _tradingMode = tradingMode;
             _portNumber = portNumber;
             _exportIbGatewayLogs = exportIbGatewayLogs;
-            _preserveAccountGroupsWithAllocationMethods = preserveAccountGroupsWithAllocationMethods;
+            _useAccountGroupsWithAllocationMethods = useAccountGroupsWithAllocationMethods;
 
             _timerLogReader = new Timer(LogReaderTimerCallback, null, Timeout.Infinite, Timeout.Infinite);
 
@@ -641,6 +643,15 @@ namespace QuantConnect.IBAutomater
                     _ibAutomaterInitializeEvent.Set();
                 }
 
+                // the requested Financial Advisor allocation groups configuration is unavailable
+                else if (text.StartsWith(FinancialAdvisorAllocationGroupsConfigurationUnavailableMarker,
+                    StringComparison.InvariantCultureIgnoreCase))
+                {
+                    _lastStartResult = new StartResult(
+                        ErrorCode.FinancialAdvisorAllocationGroupsConfigurationUnavailable,
+                        text);
+                }
+
                 // initialization completed
                 else if (text.Contains("Configuration settings updated", StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -690,7 +701,10 @@ namespace QuantConnect.IBAutomater
                 {
                     TraceIbLauncherLogFile();
 
-                    _lastStartResult = new StartResult(ErrorCode.InitializationTimeout, "Auto-restart timed out");
+                    _lastStartResult =
+                        startResult.ErrorCode == ErrorCode.FinancialAdvisorAllocationGroupsConfigurationUnavailable
+                            ? startResult
+                            : new StartResult(ErrorCode.InitializationTimeout, "Auto-restart timed out");
 
                     // the relaunched gateway may still be running (e.g. the token-expired dialog
                     // text changed and fell through to an unknown-window error, or initialization
@@ -1304,7 +1318,7 @@ namespace QuantConnect.IBAutomater
             if (enableJavaAgent)
             {
                 File.WriteAllText(javaAgentConfigFileName,
-                    $"{_userName}\n{_password}\n{_tradingMode}\n{_portNumber}\n{_exportIbGatewayLogs}\n{isRestart}\n{_preserveAccountGroupsWithAllocationMethods}");
+                    $"{_userName}\n{_password}\n{_tradingMode}\n{_portNumber}\n{_exportIbGatewayLogs}\n{isRestart}\n{_useAccountGroupsWithAllocationMethods}");
             }
             else
             {

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -440,7 +440,25 @@ namespace QuantConnect.IBAutomater
 
                 if (waitForExit)
                 {
+                    while (!process.WaitForExit(250))
+                    {
+                        if (_ibAutomaterInitializeEvent.WaitOne(0))
+                        {
+                            if (_lastStartResult.ErrorCode == ErrorCode.FinancialAdvisorAllocationGroupsConfigurationUnavailable)
+                            {
+                                process.Exited -= OnProcessExited;
+                                Stop();
+                                return _lastStartResult;
+                            }
+                            break;
+                        }
+                    }
                     process.WaitForExit();
+
+                    if (_lastStartResult.ErrorCode == ErrorCode.FinancialAdvisorAllocationGroupsConfigurationUnavailable)
+                    {
+                        return _lastStartResult;
+                    }
                 }
                 else
                 {
@@ -478,6 +496,12 @@ namespace QuantConnect.IBAutomater
 
                     if (_lastStartResult.HasError)
                     {
+                        if (_lastStartResult.ErrorCode == ErrorCode.FinancialAdvisorAllocationGroupsConfigurationUnavailable)
+                        {
+                            process.Exited -= OnProcessExited;
+                            Stop();
+                        }
+
                         message = $"IBAutomater error - Code: {_lastStartResult.ErrorCode} Message: {_lastStartResult.ErrorMessage}";
                         OutputDataReceived?.Invoke(this, new OutputDataReceivedEventArgs(message));
 
@@ -652,6 +676,7 @@ namespace QuantConnect.IBAutomater
                     _lastStartResult = new StartResult(
                         ErrorCode.FinancialAdvisorAllocationGroupsConfigurationUnavailable,
                         text);
+                    _ibAutomaterInitializeEvent.Set();
                 }
 
                 // initialization completed

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -189,6 +189,7 @@ namespace QuantConnect.IBAutomater
 
         /// <summary>
         /// Creates a new instance of the <see cref="IBAutomater"/> class
+        /// and retains the established behavior of deselecting the Use Account Groups with Allocation Methods setting
         /// </summary>
         /// <param name="ibDirectory">The root directory of IB Gateway</param>
         /// <param name="ibVersion">The IB Gateway version to launch</param>
@@ -213,7 +214,8 @@ namespace QuantConnect.IBAutomater
         /// <param name="portNumber">The API port number</param>
         /// <param name="exportIbGatewayLogs">Export IB Gateway logs if true</param>
         /// <param name="useAccountGroupsWithAllocationMethods">
-        /// Enable the Use Account Groups with Allocation Methods setting if true
+        /// The desired state of the Use Account Groups with Allocation Methods setting:
+        /// true selects it; false deselects it
         /// </param>
         public IBAutomater(
             string ibDirectory,

--- a/QuantConnect.IBAutomater/IBAutomater.cs
+++ b/QuantConnect.IBAutomater/IBAutomater.cs
@@ -41,6 +41,7 @@ namespace QuantConnect.IBAutomater
         private readonly string _tradingMode;
         private readonly int _portNumber;
         private readonly bool _exportIbGatewayLogs;
+        private readonly bool _preserveAccountGroupsWithAllocationMethods;
 
         private volatile bool _isDisposeCalled;
 
@@ -135,9 +136,23 @@ namespace QuantConnect.IBAutomater
                 ibVersion = config["ib-version"].ToString();
             }
             var exportIbGatewayLogs = config["ib-export-ibgateway-logs"].ToObject<bool>();
+            var preserveAccountGroupsWithAllocationMethods = false;
+            if (config["ib-financial-advisors-unified-groups-enabled"] != null)
+            {
+                preserveAccountGroupsWithAllocationMethods =
+                    config["ib-financial-advisors-unified-groups-enabled"].ToObject<bool>();
+            }
 
             // Create a new instance of the IBAutomater class
-            using var automater = new IBAutomater(ibDirectory, ibVersion, userName, password, tradingMode, portNumber, exportIbGatewayLogs);
+            using var automater = new IBAutomater(
+                ibDirectory,
+                ibVersion,
+                userName,
+                password,
+                tradingMode,
+                portNumber,
+                exportIbGatewayLogs,
+                preserveAccountGroupsWithAllocationMethods);
 
             // Attach the event handlers
             automater.OutputDataReceived += (s, e) => Console.WriteLine($"{DateTime.UtcNow:O} {e.Data}");
@@ -181,6 +196,32 @@ namespace QuantConnect.IBAutomater
         /// <param name="portNumber">The API port number</param>
         /// <param name="exportIbGatewayLogs">Export IB Gateway logs if true</param>
         public IBAutomater(string ibDirectory, string ibVersion, string userName, string password, string tradingMode, int portNumber, bool exportIbGatewayLogs)
+            : this(ibDirectory, ibVersion, userName, password, tradingMode, portNumber, exportIbGatewayLogs, false)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="IBAutomater"/> class
+        /// </summary>
+        /// <param name="ibDirectory">The root directory of IB Gateway</param>
+        /// <param name="ibVersion">The IB Gateway version to launch</param>
+        /// <param name="userName">The user name</param>
+        /// <param name="password">The password</param>
+        /// <param name="tradingMode">The trading mode ('paper' or 'live')</param>
+        /// <param name="portNumber">The API port number</param>
+        /// <param name="exportIbGatewayLogs">Export IB Gateway logs if true</param>
+        /// <param name="preserveAccountGroupsWithAllocationMethods">
+        /// Leave the Use Account Groups with Allocation Methods setting unchanged if true
+        /// </param>
+        public IBAutomater(
+            string ibDirectory,
+            string ibVersion,
+            string userName,
+            string password,
+            string tradingMode,
+            int portNumber,
+            bool exportIbGatewayLogs,
+            bool preserveAccountGroupsWithAllocationMethods)
         {
             _ibDirectory = ibDirectory;
             _ibVersion = ibVersion;
@@ -189,6 +230,7 @@ namespace QuantConnect.IBAutomater
             _tradingMode = tradingMode;
             _portNumber = portNumber;
             _exportIbGatewayLogs = exportIbGatewayLogs;
+            _preserveAccountGroupsWithAllocationMethods = preserveAccountGroupsWithAllocationMethods;
 
             _timerLogReader = new Timer(LogReaderTimerCallback, null, Timeout.Infinite, Timeout.Infinite);
 
@@ -1261,7 +1303,8 @@ namespace QuantConnect.IBAutomater
 
             if (enableJavaAgent)
             {
-                File.WriteAllText(javaAgentConfigFileName, $"{_userName}\n{_password}\n{_tradingMode}\n{_portNumber}\n{_exportIbGatewayLogs}\n{isRestart}");
+                File.WriteAllText(javaAgentConfigFileName,
+                    $"{_userName}\n{_password}\n{_tradingMode}\n{_portNumber}\n{_exportIbGatewayLogs}\n{isRestart}\n{_preserveAccountGroupsWithAllocationMethods}");
             }
             else
             {

--- a/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
+++ b/QuantConnect.IBAutomater/QuantConnect.IBAutomater.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net10.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>2.0.92</Version>
+    <Version>2.0.93</Version>
     <Description>QuantConnect IBAutomater</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/QuantConnect/IBAutomater</PackageProjectUrl>

--- a/QuantConnect.IBAutomater/StartResult.cs
+++ b/QuantConnect.IBAutomater/StartResult.cs
@@ -100,7 +100,12 @@ namespace QuantConnect.IBAutomater
         /// <summary>
         /// During login the gateway presented blocking account tasks we could not get past
         /// </summary>
-        LoginFailedAccountTasksRequired
+        LoginFailedAccountTasksRequired,
+
+        /// <summary>
+        /// The requested Financial Advisor allocation groups configuration is unavailable
+        /// </summary>
+        FinancialAdvisorAllocationGroupsConfigurationUnavailable
     }
 
     /// <summary>
@@ -174,6 +179,11 @@ namespace QuantConnect.IBAutomater
                 {
                     ErrorCode.LoginFailedAccountTasksRequired,
                     "Login to the IB Gateway failed because a user account-task is required. Please download the IB Gateway and follow the instructions provided https://www.interactivebrokers.com/en/trading/ibgateway-stable.php."
+                },
+                {
+                    ErrorCode.FinancialAdvisorAllocationGroupsConfigurationUnavailable,
+                    "Unified Financial Advisor allocation groups require IB Gateway v983 or later and the Use Account Groups with Allocation Methods setting to be available. " +
+                    "On a supported version, verify that the current account and configuration expose the setting, then correct the environment and redeploy."
                 }
             };
 

--- a/QuantConnect.IBAutomater/StartResult.cs
+++ b/QuantConnect.IBAutomater/StartResult.cs
@@ -103,7 +103,7 @@ namespace QuantConnect.IBAutomater
         LoginFailedAccountTasksRequired,
 
         /// <summary>
-        /// The requested Financial Advisor allocation groups configuration is unavailable
+        /// The requested Financial Advisor allocation groups setting could not be applied or verified
         /// </summary>
         FinancialAdvisorAllocationGroupsConfigurationUnavailable
     }
@@ -182,8 +182,9 @@ namespace QuantConnect.IBAutomater
                 },
                 {
                     ErrorCode.FinancialAdvisorAllocationGroupsConfigurationUnavailable,
-                    "Unified Financial Advisor allocation groups require IB Gateway v983 or later and the Use Account Groups with Allocation Methods setting to be available. " +
-                    "On a supported version, verify that the current account and configuration expose the setting, then correct the environment and redeploy."
+                    "The requested Use Account Groups with Allocation Methods setting could not be applied or verified. " +
+                    "Enabling unified Financial Advisor allocation groups requires IB Gateway v983 or later. " +
+                    "Verify the Gateway version, account configuration, and requested setting before redeploying."
                 }
             };
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,18 @@ After doing either of above steps you should now be ready to start using IBAutom
 ``` C#
 using QuantConnect.IBAutomater;
 
+var preserveAccountGroupsWithAllocationMethods = false;
+
 // Create a new instance of IBAutomater
-_ibAutomater = new IBAutomater.IBAutomater(ibDirectory, ibVersion, userName, password, tradingMode, port, exportIbGatewayLogs);
+_ibAutomater = new IBAutomater.IBAutomater(
+    ibDirectory,
+    ibVersion,
+    userName,
+    password,
+    tradingMode,
+    port,
+    exportIbGatewayLogs,
+    preserveAccountGroupsWithAllocationMethods);
 
 // You can bind to event handlers to receive the output data.
 _ibAutomater.OutputDataReceived += OnIbAutomaterOutputDataReceived;
@@ -46,6 +56,10 @@ _ibAutomater.Start(false);
 // Stop IB Gateway with a simple command.
 _ibAutomater.Stop();
 ```
+
+The original seven-parameter constructor remains supported and retains IBAutomater's established policy of deselecting the IB Gateway **Use Account Groups with Allocation Methods** setting when a recognized check box is present and selected. IBAutomater recognizes both the canonical label and the trailing-period form observed in Gateway 10.39. Pass `true` as the final parameter of the new overload to preserve the recognized check box's current state. This does not select, validate, or require the setting; an unavailable or unrecognized check box is left untouched. The value is retained when the same IBAutomater instance restarts IB Gateway and must be supplied before calling `Start`.
+
+For standalone execution, `config.json` can optionally specify `"ib-financial-advisors-unified-groups-enabled": true`; when omitted, the setting defaults to `false`. Library consumers, including LEAN, must pass the corresponding value to the constructor themselves.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The original seven-parameter constructor remains supported and retains IBAutomat
 
 The value is fixed when the IBAutomater instance is constructed and is applied again on explicit and automatic IB Gateway restarts. IBAutomater reads the control again after changing it and reports its actual state. When `true`, startup or restart fails and the Gateway is stopped if the v983+ control is absent, disabled while unchecked, or ambiguous. Under either requested state, startup also fails if a present control does not retain that state. Unified Financial Advisor allocation-group routing cannot be established safely after either failure. The returned `StartResult` explains how to verify the Gateway version and account configuration before redeploying.
 
+When unified Financial Advisor groups are enabled, IBAutomater also disables **Messages → Group Allocation Warning** when that setting is present and accepts the Gateway's resulting Financial Advisor confirmation. The warning setting is left unchanged when unified groups are disabled.
+
 For standalone execution, `config.json` can optionally specify `"ib-financial-advisors-unified-groups-enabled": true`; when omitted, the setting defaults to `false`. Library consumers, including LEAN, must pass the corresponding value to the constructor themselves.
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ _ibAutomater.Start(false);
 _ibAutomater.Stop();
 ```
 
-The original seven-parameter constructor remains supported and retains IBAutomater's established policy of deselecting the IB Gateway **Use Account Groups with Allocation Methods** setting when the recognized check box is selected. The final parameter of the new overload specifies the desired state: `true` selects the setting and `false` deselects it. IBAutomater locates the control by a case-insensitive match on the stable beginning of its label, accommodating terminal punctuation and other trailing text without broadening other check-box lookups.
+The original seven-parameter constructor remains supported and retains IBAutomater's established policy of deselecting the IB Gateway **Use Account Groups with Allocation Methods** setting when the recognized check box is selected. The `useAccountGroupsWithAllocationMethods` parameter specifies the desired state: `true` selects the setting and `false` deselects it. IBAutomater locates the control by a case-insensitive match on the stable beginning of its label, accommodating terminal punctuation and other trailing text without broadening other check-box lookups.
 
-The value is fixed when the IBAutomater instance is constructed and is applied again on explicit and automatic IB Gateway restarts. When `true`, IBAutomater fails startup or restart if the v983+ control is absent, or if it is disabled while unchecked, because unified Financial Advisor allocation-group routing cannot then be established safely. The returned `StartResult` explains how to verify the Gateway version and account configuration before redeploying.
+The value is fixed when the IBAutomater instance is constructed and is applied again on explicit and automatic IB Gateway restarts. IBAutomater reads the control again after changing it and reports its actual state. When `true`, startup or restart fails and the Gateway is stopped if the v983+ control is absent, disabled while unchecked, or ambiguous. Under either requested state, startup also fails if a present control does not retain that state. Unified Financial Advisor allocation-group routing cannot be established safely after either failure. The returned `StartResult` explains how to verify the Gateway version and account configuration before redeploying.
 
 For standalone execution, `config.json` can optionally specify `"ib-financial-advisors-unified-groups-enabled": true`; when omitted, the setting defaults to `false`. Library consumers, including LEAN, must pass the corresponding value to the constructor themselves.
 
@@ -236,6 +236,16 @@ To build the NuGet package we need to complete the following three steps in orde
 - Increment the version number in QuantConnect.IBAutomater.csproj
 - Open the solution file: /IBAutomater/IBAutomater.sln
 - Rebuild solution & test locally
+
+The Java self-tests and C# tests can also be run from the command line:
+
+``` bash
+cd java/IBAutomater
+ant clean test jar
+cd ../..
+dotnet build IBAutomater.sln -c Release
+dotnet test IBAutomater.sln -c Release
+```
 
 #### 3. NuGet upload
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ After doing either of above steps you should now be ready to start using IBAutom
 ``` C#
 using QuantConnect.IBAutomater;
 
-var preserveAccountGroupsWithAllocationMethods = false;
+var useAccountGroupsWithAllocationMethods = false;
 
 // Create a new instance of IBAutomater
 _ibAutomater = new IBAutomater.IBAutomater(
@@ -36,7 +36,7 @@ _ibAutomater = new IBAutomater.IBAutomater(
     tradingMode,
     port,
     exportIbGatewayLogs,
-    preserveAccountGroupsWithAllocationMethods);
+    useAccountGroupsWithAllocationMethods);
 
 // You can bind to event handlers to receive the output data.
 _ibAutomater.OutputDataReceived += OnIbAutomaterOutputDataReceived;
@@ -57,7 +57,9 @@ _ibAutomater.Start(false);
 _ibAutomater.Stop();
 ```
 
-The original seven-parameter constructor remains supported and retains IBAutomater's established policy of deselecting the IB Gateway **Use Account Groups with Allocation Methods** setting when a recognized check box is present and selected. IBAutomater recognizes both the canonical label and the trailing-period form observed in Gateway 10.39. Pass `true` as the final parameter of the new overload to preserve the recognized check box's current state. This does not select, validate, or require the setting; an unavailable or unrecognized check box is left untouched. The value is retained when the same IBAutomater instance restarts IB Gateway and must be supplied before calling `Start`.
+The original seven-parameter constructor remains supported and retains IBAutomater's established policy of deselecting the IB Gateway **Use Account Groups with Allocation Methods** setting when the recognized check box is selected. The final parameter of the new overload specifies the desired state: `true` selects the setting and `false` deselects it. IBAutomater locates the control by a case-insensitive match on the stable beginning of its label, accommodating terminal punctuation and other trailing text without broadening other check-box lookups.
+
+The value is fixed when the IBAutomater instance is constructed and is applied again on explicit and automatic IB Gateway restarts. When `true`, IBAutomater fails startup or restart if the v983+ control is absent, or if it is disabled while unchecked, because unified Financial Advisor allocation-group routing cannot then be established safely. The returned `StartResult` explains how to verify the Gateway version and account configuration before redeploying.
 
 For standalone execution, `config.json` can optionally specify `"ib-financial-advisors-unified-groups-enabled": true`; when omitted, the setting defaults to `false`. Library consumers, including LEAN, must pass the corresponding value to the constructor themselves.
 

--- a/java/IBAutomater/build.xml
+++ b/java/IBAutomater/build.xml
@@ -10,6 +10,29 @@
 <project name="IBAutomater" default="default" basedir=".">
     <description>Builds, tests, and runs the project IBAutomater.</description>
     <import file="nbproject/build-impl.xml"/>
+
+    <!-- The project intentionally has no external Java test dependency. -->
+    <target name="self-test" depends="compile">
+        <mkdir dir="${build.test.classes.dir}"/>
+        <javac srcdir="${test.src.dir}"
+               destdir="${build.test.classes.dir}"
+               source="${javac.source}"
+               target="${javac.target}"
+               encoding="${source.encoding}"
+               includeantruntime="false">
+            <classpath>
+                <pathelement location="${build.classes.dir}"/>
+            </classpath>
+        </javac>
+        <java classname="ibautomater.IBAutomaterSelfTest" fork="true" failonerror="true">
+            <classpath>
+                <pathelement location="${build.classes.dir}"/>
+                <pathelement location="${build.test.classes.dir}"/>
+            </classpath>
+        </java>
+    </target>
+
+    <target name="test" depends="self-test"/>
     <!--
 
     There exist several targets which are by default empty and which can be 

--- a/java/IBAutomater/src/ibautomater/IBAutomater.java
+++ b/java/IBAutomater/src/ibautomater/IBAutomater.java
@@ -51,11 +51,11 @@ public final class IBAutomater {
         int portNumber = Integer.parseInt(argValues[3]);
         boolean exportIbGatewayLogs = Boolean.parseBoolean(argValues[4]);
         boolean restarting = Boolean.parseBoolean(argValues[5]);
-        boolean preserveAccountGroupsWithAllocationMethods =
+        boolean useAccountGroupsWithAllocationMethods =
             argValues.length > 6 && Boolean.parseBoolean(argValues[6]);
 
         IBAutomater automater = new IBAutomater(userName, password, tradingMode, portNumber,
-            exportIbGatewayLogs, restarting, preserveAccountGroupsWithAllocationMethods);
+            exportIbGatewayLogs, restarting, useAccountGroupsWithAllocationMethods);
     }
 
     /**
@@ -85,13 +85,13 @@ public final class IBAutomater {
      * (currently at startup and when unknown windows are detected)
      * @param restarting If true, the automater will assume the gateway is starting after a
      * soft daily restart and won't try to log in
-     * @param preserveAccountGroupsWithAllocationMethods If true, the automater will leave the
-     * "Use Account Groups with Allocation Methods" check box unchanged
+     * @param useAccountGroupsWithAllocationMethods If true, the automater will select the
+     * "Use Account Groups with Allocation Methods" check box
      */
     public IBAutomater(String userName, String password, String tradingMode, int portNumber,
-        boolean exportIbGatewayLogs, boolean restarting, boolean preserveAccountGroupsWithAllocationMethods) {
+        boolean exportIbGatewayLogs, boolean restarting, boolean useAccountGroupsWithAllocationMethods) {
         this.settings = new Settings(userName, password, tradingMode, portNumber, exportIbGatewayLogs,
-            restarting, preserveAccountGroupsWithAllocationMethods);
+            restarting, useAccountGroupsWithAllocationMethods);
 
         try
         {

--- a/java/IBAutomater/src/ibautomater/IBAutomater.java
+++ b/java/IBAutomater/src/ibautomater/IBAutomater.java
@@ -51,8 +51,11 @@ public final class IBAutomater {
         int portNumber = Integer.parseInt(argValues[3]);
         boolean exportIbGatewayLogs = Boolean.parseBoolean(argValues[4]);
         boolean restarting = Boolean.parseBoolean(argValues[5]);
+        boolean preserveAccountGroupsWithAllocationMethods =
+            argValues.length > 6 && Boolean.parseBoolean(argValues[6]);
 
-        IBAutomater automater = new IBAutomater(userName, password, tradingMode, portNumber, exportIbGatewayLogs, restarting);
+        IBAutomater automater = new IBAutomater(userName, password, tradingMode, portNumber,
+            exportIbGatewayLogs, restarting, preserveAccountGroupsWithAllocationMethods);
     }
 
     /**
@@ -68,7 +71,27 @@ public final class IBAutomater {
      * soft daily restart and won't try to log in
      */
     public IBAutomater(String userName, String password, String tradingMode, int portNumber, boolean exportIbGatewayLogs, boolean restarting) {
-        this.settings = new Settings(userName, password, tradingMode, portNumber, exportIbGatewayLogs, restarting);
+        this(userName, password, tradingMode, portNumber, exportIbGatewayLogs, restarting, false);
+    }
+
+    /**
+     * Creates a new instance of the {@link IBAutomater} class.
+     *
+     * @param userName The IB user name
+     * @param password The IB password
+     * @param tradingMode The trading mode (allowed values are "live" and "paper")
+     * @param portNumber The socket port number to be used for API connections
+     * @param exportIbGatewayLogs If true, IBGateway logs will be exported at predefined times
+     * (currently at startup and when unknown windows are detected)
+     * @param restarting If true, the automater will assume the gateway is starting after a
+     * soft daily restart and won't try to log in
+     * @param preserveAccountGroupsWithAllocationMethods If true, the automater will leave the
+     * "Use Account Groups with Allocation Methods" check box unchanged
+     */
+    public IBAutomater(String userName, String password, String tradingMode, int portNumber,
+        boolean exportIbGatewayLogs, boolean restarting, boolean preserveAccountGroupsWithAllocationMethods) {
+        this.settings = new Settings(userName, password, tradingMode, portNumber, exportIbGatewayLogs,
+            restarting, preserveAccountGroupsWithAllocationMethods);
 
         try
         {

--- a/java/IBAutomater/src/ibautomater/IBAutomater.java
+++ b/java/IBAutomater/src/ibautomater/IBAutomater.java
@@ -60,6 +60,8 @@ public final class IBAutomater {
 
     /**
      * Creates a new instance of the {@link IBAutomater} class.
+     * This overload retains the established behavior of deselecting the
+     * "Use Account Groups with Allocation Methods" check box.
      *
      * @param userName The IB user name
      * @param password The IB password
@@ -85,8 +87,8 @@ public final class IBAutomater {
      * (currently at startup and when unknown windows are detected)
      * @param restarting If true, the automater will assume the gateway is starting after a
      * soft daily restart and won't try to log in
-     * @param useAccountGroupsWithAllocationMethods If true, the automater will select the
-     * "Use Account Groups with Allocation Methods" check box
+     * @param useAccountGroupsWithAllocationMethods The desired state of the
+     * "Use Account Groups with Allocation Methods" check box: true selects it; false deselects it
      */
     public IBAutomater(String userName, String password, String tradingMode, int portNumber,
         boolean exportIbGatewayLogs, boolean restarting, boolean useAccountGroupsWithAllocationMethods) {

--- a/java/IBAutomater/src/ibautomater/Settings.java
+++ b/java/IBAutomater/src/ibautomater/Settings.java
@@ -27,6 +27,7 @@ public class Settings {
     private final int portNumber;
     private final boolean exportIbGatewayLogs;
     private final boolean restarting;
+    private final boolean preserveAccountGroupsWithAllocationMethods;
 
     /**
      * Creates a new instance of the {@link Settings} class.
@@ -41,12 +42,32 @@ public class Settings {
      * soft daily restart and won't try to log in
      */
     public Settings(String userName, String password, String tradingMode, int portNumber, boolean exportIbGatewayLogs, boolean restarting) {
+        this(userName, password, tradingMode, portNumber, exportIbGatewayLogs, restarting, false);
+    }
+
+    /**
+     * Creates a new instance of the {@link Settings} class.
+     *
+     * @param userName The IB user name
+     * @param password The IB password
+     * @param tradingMode The trading mode (allowed values are "live" and "paper")
+     * @param portNumber The socket port number to be used for API connections
+     * @param exportIbGatewayLogs If true, IBGateway logs will be exported at predefined times
+     * (currently at startup and when unknown windows are detected)
+     * @param restarting If true, the automater will assume the gateway is starting after a
+     * soft daily restart and won't try to log in
+     * @param preserveAccountGroupsWithAllocationMethods If true, the automater will leave the
+     * "Use Account Groups with Allocation Methods" check box unchanged
+     */
+    public Settings(String userName, String password, String tradingMode, int portNumber,
+        boolean exportIbGatewayLogs, boolean restarting, boolean preserveAccountGroupsWithAllocationMethods) {
         this.userName = userName;
         this.password = password;
         this.tradingMode = tradingMode;
         this.portNumber = portNumber;
         this.exportIbGatewayLogs = exportIbGatewayLogs;
         this.restarting = restarting;
+        this.preserveAccountGroupsWithAllocationMethods = preserveAccountGroupsWithAllocationMethods;
     }
 
     /**
@@ -102,5 +123,13 @@ public class Settings {
     public boolean getRestarting() {
         return this.restarting;
     }
-}
 
+    /**
+     * Gets whether the "Use Account Groups with Allocation Methods" check box should be preserved.
+     *
+     * @return Returns true if the check box should be left unchanged
+     */
+    public boolean getPreserveAccountGroupsWithAllocationMethods() {
+        return this.preserveAccountGroupsWithAllocationMethods;
+    }
+}

--- a/java/IBAutomater/src/ibautomater/Settings.java
+++ b/java/IBAutomater/src/ibautomater/Settings.java
@@ -27,7 +27,7 @@ public class Settings {
     private final int portNumber;
     private final boolean exportIbGatewayLogs;
     private final boolean restarting;
-    private final boolean preserveAccountGroupsWithAllocationMethods;
+    private final boolean useAccountGroupsWithAllocationMethods;
 
     /**
      * Creates a new instance of the {@link Settings} class.
@@ -56,18 +56,18 @@ public class Settings {
      * (currently at startup and when unknown windows are detected)
      * @param restarting If true, the automater will assume the gateway is starting after a
      * soft daily restart and won't try to log in
-     * @param preserveAccountGroupsWithAllocationMethods If true, the automater will leave the
-     * "Use Account Groups with Allocation Methods" check box unchanged
+     * @param useAccountGroupsWithAllocationMethods If true, the automater will select the
+     * "Use Account Groups with Allocation Methods" check box
      */
     public Settings(String userName, String password, String tradingMode, int portNumber,
-        boolean exportIbGatewayLogs, boolean restarting, boolean preserveAccountGroupsWithAllocationMethods) {
+        boolean exportIbGatewayLogs, boolean restarting, boolean useAccountGroupsWithAllocationMethods) {
         this.userName = userName;
         this.password = password;
         this.tradingMode = tradingMode;
         this.portNumber = portNumber;
         this.exportIbGatewayLogs = exportIbGatewayLogs;
         this.restarting = restarting;
-        this.preserveAccountGroupsWithAllocationMethods = preserveAccountGroupsWithAllocationMethods;
+        this.useAccountGroupsWithAllocationMethods = useAccountGroupsWithAllocationMethods;
     }
 
     /**
@@ -125,11 +125,11 @@ public class Settings {
     }
 
     /**
-     * Gets whether the "Use Account Groups with Allocation Methods" check box should be preserved.
+     * Gets whether the "Use Account Groups with Allocation Methods" check box should be selected.
      *
-     * @return Returns true if the check box should be left unchanged
+     * @return Returns true if the check box should be selected
      */
-    public boolean getPreserveAccountGroupsWithAllocationMethods() {
-        return this.preserveAccountGroupsWithAllocationMethods;
+    public boolean getUseAccountGroupsWithAllocationMethods() {
+        return this.useAccountGroupsWithAllocationMethods;
     }
 }

--- a/java/IBAutomater/src/ibautomater/Settings.java
+++ b/java/IBAutomater/src/ibautomater/Settings.java
@@ -31,6 +31,8 @@ public class Settings {
 
     /**
      * Creates a new instance of the {@link Settings} class.
+     * This overload retains the established behavior of deselecting the
+     * "Use Account Groups with Allocation Methods" check box.
      *
      * @param userName The IB user name
      * @param password The IB password
@@ -56,8 +58,8 @@ public class Settings {
      * (currently at startup and when unknown windows are detected)
      * @param restarting If true, the automater will assume the gateway is starting after a
      * soft daily restart and won't try to log in
-     * @param useAccountGroupsWithAllocationMethods If true, the automater will select the
-     * "Use Account Groups with Allocation Methods" check box
+     * @param useAccountGroupsWithAllocationMethods The desired state of the
+     * "Use Account Groups with Allocation Methods" check box: true selects it; false deselects it
      */
     public Settings(String userName, String password, String tradingMode, int portNumber,
         boolean exportIbGatewayLogs, boolean restarting, boolean useAccountGroupsWithAllocationMethods) {

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -658,7 +658,7 @@ public class WindowEventListener implements AWTEventListener {
      *   - deselects the "Read-Only API" check box
      *   - sets the API Port Number
      *   - selects the "Create API message log file" check box
-     *   - conditionally deselects the "Use Account Groups with Allocation Methods" check box
+     *   - sets the "Use Account Groups with Allocation Methods" check box according to configuration
      * - in the Configuration/API/Precautions panel:
      *   - selects the "Bypass Order Precautions for API Orders" check box
      * - in the Configuration/Lock and Exit panel:
@@ -718,21 +718,40 @@ public class WindowEventListener implements AWTEventListener {
 
         // v983+
         String faText = "Use Account Groups with Allocation Methods";
-        boolean preserveAccountGroupsWithAllocationMethods =
-            this.automater.getSettings().getPreserveAccountGroupsWithAllocationMethods();
-        JCheckBox faCheckBox = Common.getCheckBox(window, faText);
-        if (faCheckBox == null) {
-            // Gateway 10.39 includes a trailing period in the check box label.
-            faCheckBox = Common.getCheckBox(window, faText + ".");
-        }
-        if (faCheckBox == null) {
-            if (preserveAccountGroupsWithAllocationMethods) {
-                this.automater.logMessage("Checkbox not found: [" + faText + "]");
+        boolean useAccountGroupsWithAllocationMethods =
+            this.automater.getSettings().getUseAccountGroupsWithAllocationMethods();
+        JCheckBox faCheckBox = null;
+        for (Component component : Common.getComponents(window)) {
+            if (component instanceof JCheckBox) {
+                JCheckBox checkBox = (JCheckBox)component;
+                String checkBoxText = checkBox.getText();
+                if (checkBoxText != null &&
+                    checkBoxText.regionMatches(true, 0, faText, 0, faText.length())) {
+                    faCheckBox = checkBox;
+                    break;
+                }
             }
         }
-        else if (preserveAccountGroupsWithAllocationMethods) {
-            this.automater.logMessage("Leaving checkbox unchanged: [" + faText +
-                "] - Selected: [" + faCheckBox.isSelected() + "]");
+        if (faCheckBox == null) {
+            if (useAccountGroupsWithAllocationMethods) {
+                this.automater.logMessage(
+                    "Error: Financial Advisor allocation groups configuration unavailable: [" + faText +
+                    "] - Reason: [check box not found]");
+            }
+        }
+        else if (useAccountGroupsWithAllocationMethods) {
+            if (!faCheckBox.isSelected() && !faCheckBox.isEnabled()) {
+                this.automater.logMessage(
+                    "Error: Financial Advisor allocation groups configuration unavailable: [" + faText +
+                    "] - Reason: [check box is disabled and unchecked]");
+            }
+            else {
+                if (!faCheckBox.isSelected()) {
+                    this.automater.logMessage("Select checkbox: [" + faText + "]");
+                    faCheckBox.setSelected(true);
+                }
+                this.automater.logMessage("Checkbox: [" + faText + "] - Selected: [true]");
+            }
         }
         else if (faCheckBox.isSelected()) {
             this.automater.logMessage("Unselect checkbox: [" + faText + "]");

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -17,6 +17,7 @@ package ibautomater;
 
 import java.awt.AWTEvent;
 import java.awt.Component;
+import java.awt.Container;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.AWTEventListener;
@@ -25,6 +26,7 @@ import java.io.File;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -35,6 +37,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFrame;
@@ -717,45 +720,15 @@ public class WindowEventListener implements AWTEventListener {
         }
 
         // v983+
-        String faText = "Use Account Groups with Allocation Methods";
         boolean useAccountGroupsWithAllocationMethods =
             this.automater.getSettings().getUseAccountGroupsWithAllocationMethods();
-        JCheckBox faCheckBox = null;
-        for (Component component : Common.getComponents(window)) {
-            if (component instanceof JCheckBox) {
-                JCheckBox checkBox = (JCheckBox)component;
-                String checkBoxText = checkBox.getText();
-                if (checkBoxText != null &&
-                    checkBoxText.regionMatches(true, 0, faText, 0, faText.length())) {
-                    faCheckBox = checkBox;
-                    break;
-                }
-            }
-        }
-        if (faCheckBox == null) {
-            if (useAccountGroupsWithAllocationMethods) {
-                this.automater.logMessage(
-                    "Error: Financial Advisor allocation groups configuration unavailable: [" + faText +
-                    "] - Reason: [check box not found]");
-            }
-        }
-        else if (useAccountGroupsWithAllocationMethods) {
-            if (!faCheckBox.isSelected() && !faCheckBox.isEnabled()) {
-                this.automater.logMessage(
-                    "Error: Financial Advisor allocation groups configuration unavailable: [" + faText +
-                    "] - Reason: [check box is disabled and unchecked]");
-            }
-            else {
-                if (!faCheckBox.isSelected()) {
-                    this.automater.logMessage("Select checkbox: [" + faText + "]");
-                    faCheckBox.setSelected(true);
-                }
-                this.automater.logMessage("Checkbox: [" + faText + "] - Selected: [true]");
-            }
-        }
-        else if (faCheckBox.isSelected()) {
-            this.automater.logMessage("Unselect checkbox: [" + faText + "]");
-            faCheckBox.setSelected(false);
+        String financialAdvisorCheckBoxError = ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+            window, useAccountGroupsWithAllocationMethods, this.automater::logMessage);
+        if (financialAdvisorCheckBoxError != null) {
+            this.automater.logMessage(
+                "Error: Financial Advisor allocation groups configuration unavailable: [" +
+                "Use Account Groups with Allocation Methods] - Reason: [" +
+                financialAdvisorCheckBoxError + "]");
         }
 
         Common.selectTreeNode(tree, new TreePath(new String[]{"Configuration", "API", "Precautions"}));
@@ -847,9 +820,52 @@ public class WindowEventListener implements AWTEventListener {
             SaveIBLogs();
         }
 
-        this.automater.logMessage("Configuration settings updated.");
+        if (financialAdvisorCheckBoxError == null) {
+            this.automater.logMessage("Configuration settings updated.");
+        }
 
         return true;
+    }
+
+    static String ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+        Container container, boolean desiredState, Consumer<String> log) {
+        String checkBoxText = "Use Account Groups with Allocation Methods";
+        List<JCheckBox> matches = new ArrayList<>();
+        for (Component component : Common.getComponents(container)) {
+            if (component instanceof JCheckBox) {
+                JCheckBox checkBox = (JCheckBox)component;
+                String text = checkBox.getText();
+                if (text != null && text.regionMatches(true, 0, checkBoxText, 0, checkBoxText.length())) {
+                    matches.add(checkBox);
+                }
+            }
+        }
+
+        if (matches.isEmpty()) {
+            return desiredState ? "check box not found" : null;
+        }
+        if (desiredState && matches.size() != 1) {
+            return "multiple matching check boxes found";
+        }
+
+        for (JCheckBox checkBox : matches) {
+            if (checkBox.isSelected() != desiredState) {
+                if (desiredState && !checkBox.isEnabled()) {
+                    log.accept("Checkbox: [" + checkBoxText + "] - Selected: [" +
+                        checkBox.isSelected() + "]");
+                    return "check box is disabled and unchecked";
+                }
+                log.accept((desiredState ? "Select" : "Unselect") + " checkbox: [" + checkBoxText + "]");
+                checkBox.setSelected(desiredState);
+            }
+
+            boolean actualState = checkBox.isSelected();
+            log.accept("Checkbox: [" + checkBoxText + "] - Selected: [" + actualState + "]");
+            if (actualState != desiredState) {
+                return "check box did not retain the requested state";
+            }
+        }
+        return null;
     }
 
     /**

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -658,7 +658,7 @@ public class WindowEventListener implements AWTEventListener {
      *   - deselects the "Read-Only API" check box
      *   - sets the API Port Number
      *   - selects the "Create API message log file" check box
-     *   - deselects the "Use Account Groups with Allocation Methods" check box
+     *   - conditionally deselects the "Use Account Groups with Allocation Methods" check box
      * - in the Configuration/API/Precautions panel:
      *   - selects the "Bypass Order Precautions for API Orders" check box
      * - in the Configuration/Lock and Exit panel:
@@ -718,8 +718,23 @@ public class WindowEventListener implements AWTEventListener {
 
         // v983+
         String faText = "Use Account Groups with Allocation Methods";
+        boolean preserveAccountGroupsWithAllocationMethods =
+            this.automater.getSettings().getPreserveAccountGroupsWithAllocationMethods();
         JCheckBox faCheckBox = Common.getCheckBox(window, faText);
-        if (faCheckBox != null && faCheckBox.isSelected()) {
+        if (faCheckBox == null) {
+            // Gateway 10.39 includes a trailing period in the check box label.
+            faCheckBox = Common.getCheckBox(window, faText + ".");
+        }
+        if (faCheckBox == null) {
+            if (preserveAccountGroupsWithAllocationMethods) {
+                this.automater.logMessage("Checkbox not found: [" + faText + "]");
+            }
+        }
+        else if (preserveAccountGroupsWithAllocationMethods) {
+            this.automater.logMessage("Leaving checkbox unchanged: [" + faText +
+                "] - Selected: [" + faCheckBox.isSelected() + "]");
+        }
+        else if (faCheckBox.isSelected()) {
             this.automater.logMessage("Unselect checkbox: [" + faText + "]");
             faCheckBox.setSelected(false);
         }

--- a/java/IBAutomater/src/ibautomater/WindowEventListener.java
+++ b/java/IBAutomater/src/ibautomater/WindowEventListener.java
@@ -46,6 +46,7 @@ import javax.swing.JList;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JRadioButton;
+import javax.swing.JTable;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.JTextPane;
@@ -664,6 +665,8 @@ public class WindowEventListener implements AWTEventListener {
      *   - sets the "Use Account Groups with Allocation Methods" check box according to configuration
      * - in the Configuration/API/Precautions panel:
      *   - selects the "Bypass Order Precautions for API Orders" check box
+     * - in the Configuration/Messages panel:
+     *   - disables the "Group Allocation Warning" message for unified Financial Advisor groups
      * - in the Configuration/Lock and Exit panel:
      *   - selects the "Auto restart" check box
      * - if requested, opens the Export IB logs window
@@ -757,6 +760,11 @@ public class WindowEventListener implements AWTEventListener {
                     checkBox.setSelected(true);
                 }
             }
+        }
+
+        if (useAccountGroupsWithAllocationMethods) {
+            Common.selectTreeNode(tree, new TreePath(new String[]{"Configuration", "Messages"}));
+            DisableGroupAllocationWarning(window, this.automater::logMessage);
         }
 
         Common.selectTreeNode(tree, new TreePath(new String[]{"Configuration", "Lock and Exit"}));
@@ -868,6 +876,51 @@ public class WindowEventListener implements AWTEventListener {
         return null;
     }
 
+    static void DisableGroupAllocationWarning(Container container, Consumer<String> log) {
+        String messageText = "Group Allocation Warning";
+        for (Component component : Common.getComponents(container)) {
+            if (!(component instanceof JTable)) {
+                continue;
+            }
+
+            JTable table = (JTable)component;
+            int messageColumn = -1;
+            int enabledColumn = -1;
+            for (int column = 0; column < table.getColumnCount(); column++) {
+                String columnName = table.getColumnName(column);
+                if ("Message".equalsIgnoreCase(columnName) ||
+                    "Message Name".equalsIgnoreCase(columnName)) {
+                    messageColumn = column;
+                }
+                else if ("Enabled".equalsIgnoreCase(columnName)) {
+                    enabledColumn = column;
+                }
+            }
+            if (messageColumn == -1 || enabledColumn == -1) {
+                continue;
+            }
+
+            for (int row = 0; row < table.getRowCount(); row++) {
+                Object message = table.getValueAt(row, messageColumn);
+                if (message == null || !messageText.equalsIgnoreCase(message.toString())) {
+                    continue;
+                }
+
+                boolean enabled = Boolean.TRUE.equals(table.getValueAt(row, enabledColumn));
+                log.accept("Message: [" + messageText + "] - Enabled: [" + enabled + "]");
+                if (enabled) {
+                    log.accept("Disable message: [" + messageText + "]");
+                    table.setValueAt(Boolean.FALSE, row, enabledColumn);
+                    log.accept("Message: [" + messageText + "] - Enabled: [" +
+                        Boolean.TRUE.equals(table.getValueAt(row, enabledColumn)) + "]");
+                }
+                return;
+            }
+        }
+
+        log.accept("Message setting not found: [" + messageText + "]");
+    }
+
     /**
      * Detects and handles the Existing Session Detected window.
      * - clicks the "Exit Application" button
@@ -958,8 +1011,8 @@ public class WindowEventListener implements AWTEventListener {
     /**
      * Detects and handles the Financial Advisor warning window.
      * - logs the window structure
-     * - clicks the "Yes" button
-     * - checks whether the window closed after the click
+     * - clicks the "Accept and Continue" configuration button or the "Yes" order button
+     * - checks whether the window closed after an order-warning click
      *
      * @param window The window instance
      * @param eventId The id of the window event
@@ -976,6 +1029,14 @@ public class WindowEventListener implements AWTEventListener {
         if (title != null && title.contains("Financial Advisor Warning")) {
             
             LogWindowContents(window);
+
+            String confirmationButtonText = "Accept and Continue";
+            JButton confirmationButton = Common.getButton(window, confirmationButtonText);
+            if (confirmationButton != null) {
+                this.automater.logMessage("Click button: [" + confirmationButtonText + "]");
+                confirmationButton.doClick();
+                return true;
+            }
 
             String buttonText = "Yes";
             JButton button = Common.getButton(window, buttonText);

--- a/java/IBAutomater/test/ibautomater/IBAutomaterSelfTest.java
+++ b/java/IBAutomater/test/ibautomater/IBAutomaterSelfTest.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JCheckBox;
 import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
 
 /**
  * Dependency-free tests for Financial Advisor Gateway configuration helpers.
@@ -25,11 +27,63 @@ public final class IBAutomaterSelfTest {
 
     public static void main(String[] args) {
         TestFinancialAdvisorAllocationGroupsCheckBox();
+        TestGroupAllocationWarningMessage();
 
         if (assertions == 0) {
             throw new AssertionError("No self-test assertions executed");
         }
         System.out.println("IBAutomater Java self-tests passed: " + assertions + " assertions");
+    }
+
+    private static void TestGroupAllocationWarningMessage() {
+        List<String> messages = new ArrayList<>();
+        JPanel panel = new JPanel();
+        JTable table = CreateMessagesTable(Boolean.TRUE);
+        panel.add(table);
+
+        WindowEventListener.DisableGroupAllocationWarning(panel, messages::add);
+        AssertEquals(Boolean.FALSE, table.getValueAt(1, 2));
+        AssertEquals(Boolean.TRUE, table.getValueAt(0, 2));
+        AssertEquals("Message: [Group Allocation Warning] - Enabled: [false]",
+            messages.get(messages.size() - 1));
+
+        messages.clear();
+        WindowEventListener.DisableGroupAllocationWarning(panel, messages::add);
+        AssertEquals(Boolean.FALSE, table.getValueAt(1, 2));
+        AssertEquals(1, messages.size());
+        AssertEquals("Message: [Group Allocation Warning] - Enabled: [false]", messages.get(0));
+
+        panel = new JPanel();
+        table = CreateMessagesTable(Boolean.TRUE);
+        table.moveColumn(2, 0);
+        panel.add(table);
+        WindowEventListener.DisableGroupAllocationWarning(panel, messages::add);
+        AssertEquals(Boolean.FALSE, table.getValueAt(1, 0));
+
+        panel = new JPanel();
+        table = new JTable(new Object[][]{{"group allocation warning", Boolean.TRUE}},
+            new Object[]{"Message", "Enabled"});
+        panel.add(table);
+        WindowEventListener.DisableGroupAllocationWarning(panel, messages::add);
+        AssertEquals(Boolean.FALSE, table.getValueAt(0, 1));
+
+        messages.clear();
+        panel = new JPanel();
+        table = new JTable(new Object[][]{{"Other Warning", Boolean.TRUE}},
+            new Object[]{"Message", "Enabled"});
+        panel.add(table);
+        WindowEventListener.DisableGroupAllocationWarning(panel, messages::add);
+        AssertEquals(Boolean.TRUE, table.getValueAt(0, 1));
+        AssertEquals("Message setting not found: [Group Allocation Warning]", messages.get(0));
+    }
+
+    private static JTable CreateMessagesTable(Boolean groupAllocationWarningEnabled) {
+        return new JTable(new DefaultTableModel(
+            new Object[][]{
+                {"Other Warning", "Ask", Boolean.TRUE},
+                {"Group Allocation Warning", "Ask", groupAllocationWarningEnabled}
+            },
+            new Object[]{"Message Name", "Default Action", "Enabled"}));
     }
 
     private static void TestFinancialAdvisorAllocationGroupsCheckBox() {

--- a/java/IBAutomater/test/ibautomater/IBAutomaterSelfTest.java
+++ b/java/IBAutomater/test/ibautomater/IBAutomaterSelfTest.java
@@ -1,0 +1,132 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * IBAutomater v1.0. Copyright 2019 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package ibautomater;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JCheckBox;
+import javax.swing.JPanel;
+
+/**
+ * Dependency-free tests for Financial Advisor Gateway configuration helpers.
+ * The Ant test target fails on the first error.
+ */
+public final class IBAutomaterSelfTest {
+    private static int assertions;
+
+    public static void main(String[] args) {
+        TestFinancialAdvisorAllocationGroupsCheckBox();
+
+        if (assertions == 0) {
+            throw new AssertionError("No self-test assertions executed");
+        }
+        System.out.println("IBAutomater Java self-tests passed: " + assertions + " assertions");
+    }
+
+    private static void TestFinancialAdvisorAllocationGroupsCheckBox() {
+        String checkBoxText = "Use Account Groups with Allocation Methods";
+        List<String> messages = new ArrayList<>();
+
+        JPanel panel = new JPanel();
+        JCheckBox checkBox = new JCheckBox(checkBoxText);
+        panel.add(checkBox);
+        AssertEquals(null, WindowEventListener.ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+            panel, true, messages::add));
+        AssertTrue(checkBox.isSelected());
+        AssertEquals("Checkbox: [" + checkBoxText + "] - Selected: [true]",
+            messages.get(messages.size() - 1));
+
+        panel = new JPanel();
+        checkBox = new JCheckBox("use account groups with allocation methods (recommended)", true);
+        panel.add(checkBox);
+        AssertEquals(null, WindowEventListener.ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+            panel, true, messages::add));
+        AssertTrue(checkBox.isSelected());
+
+        AssertEquals("check box not found",
+            WindowEventListener.ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+                new JPanel(), true, messages::add));
+        AssertEquals(null, WindowEventListener.ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+            new JPanel(), false, messages::add));
+
+        panel = new JPanel();
+        JCheckBox first = new JCheckBox(checkBoxText);
+        JCheckBox second = new JCheckBox(checkBoxText + ".");
+        panel.add(first);
+        panel.add(second);
+        AssertEquals("multiple matching check boxes found",
+            WindowEventListener.ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+                panel, true, messages::add));
+        AssertTrue(!first.isSelected() && !second.isSelected());
+        first.setSelected(true);
+        second.setSelected(true);
+        AssertEquals(null, WindowEventListener.ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+            panel, false, messages::add));
+        AssertTrue(!first.isSelected() && !second.isSelected());
+
+        panel = new JPanel();
+        checkBox = new JCheckBox(checkBoxText);
+        checkBox.setEnabled(false);
+        panel.add(checkBox);
+        AssertEquals("check box is disabled and unchecked",
+            WindowEventListener.ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+                panel, true, messages::add));
+        checkBox.setSelected(true);
+        AssertEquals(null, WindowEventListener.ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+            panel, true, messages::add));
+        AssertTrue(checkBox.isSelected());
+
+        panel = new JPanel();
+        checkBox = new NonSelectableCheckBox(checkBoxText, false);
+        panel.add(checkBox);
+        AssertEquals("check box did not retain the requested state",
+            WindowEventListener.ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+                panel, true, messages::add));
+
+        panel = new JPanel();
+        checkBox = new NonSelectableCheckBox(checkBoxText, true);
+        panel.add(checkBox);
+        AssertEquals("check box did not retain the requested state",
+            WindowEventListener.ConfigureFinancialAdvisorAllocationGroupsCheckBox(
+                panel, false, messages::add));
+    }
+
+    private static void AssertTrue(boolean condition) {
+        assertions++;
+        if (!condition) {
+            throw new AssertionError("Expected condition to be true");
+        }
+    }
+
+    private static void AssertEquals(Object expected, Object actual) {
+        assertions++;
+        if (expected == null ? actual != null : !expected.equals(actual)) {
+            throw new AssertionError("Expected [" + expected + "] but found [" + actual + "]");
+        }
+    }
+
+    private static final class NonSelectableCheckBox extends JCheckBox {
+        private boolean blockSelection;
+
+        private NonSelectableCheckBox(String text, boolean selected) {
+            super(text, selected);
+            blockSelection = true;
+        }
+
+        @Override
+        public void setSelected(boolean selected) {
+            if (!blockSelection) {
+                super.setSelected(selected);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds an optional desired state for IB Gateway's **Use Account Groups with Allocation Methods** setting. It is the IBAutomater prerequisite for LEAN's unified financial-advisor group routing. 

There have been historical PRs that have flipped the group allocation setting back and forth. The IB API behaves differently based on if this setting is selected for advisors. This update, in combination with the linked PRs open in the other repos, makes this setting user definable to ensure it has the correct setting for the deployment. The default is its existing behavior. The bug fix component addresses that the existing IBAutomater desired outcome for this setting wasn't reached across IBGateway versions that have different punctuation for the setting from what the existing code realized. 

- Threads the desired state from the C# host into the Java agent while preserving all existing constructors.
- Applies the desired state during initial launch and every explicit or automatic Gateway restart.
- When unified groups are requested, requires exactly one recognized checkbox and verifies that it is selected.
- Returns an actionable startup failure when a requested true state encounters a missing, ambiguous, disabled-and-unchecked, or non-retaining checkbox.
- Preserves legacy best-effort behavior when the setting is false or omitted, including Gateway versions where the control is absent.
- Opens the Gateway Messages settings and disables the recognized Group Allocation Warning, if present, when unified groups are enabled.
- Handles the resulting Accept and Continue confirmation.
- Leaves the Group Allocation Warning unchanged when unified groups are disabled.
- Propagates the Java configuration result through the existing startup synchronization path, so Gateway startup cannot be reported successful before the requested checkbox state is confirmed or an actionable failure is received.
- Adds focused C# and Java production-path tests and an Ant test target.

This closes: [QuantConnect/IBAutomater#112](https://github.com/QuantConnect/IBAutomater/issues/112)
** This is part of a coordinated multi-repo feature release. See the attached files for thorough details**

Hosted QuantConnect Cloud availability additionally requires the deployment schema/UI to expose and serialize the corresponding brokerage setting.

## Behavior

Requested state | Recognized Gateway control | Result
-- | -- | --
false or omitted | One or more recognized controls selected | Deselect and verify all recognized controls
false or omitted | Recognized control unselected | Leave it unselected
false or omitted | Missing | Preserve the existing no-op behavior
true | Exactly one control, enabled and unselected | Select it and verify it remains selected
true | Exactly one control already selected, including a disabled control | Leave it selected and continue
true | Missing | Return FinancialAdvisorAllocationGroupsConfigurationUnavailable
true | Disabled and unchecked | Return FinancialAdvisorAllocationGroupsConfigurationUnavailable
Either state | Recognized control does not retain the requested state | Return FinancialAdvisorAllocationGroupsConfigurationUnavailable

</body></html>

The result reports whether the recognized Swing control reached the requested state. 

## Compatibility

- The original seven-parameter public C# constructor is unchanged and defaults the new setting to `false`.
- Existing Java constructors and legacy six-line Java-agent settings remain accepted with the setting disabled.
- Existing error-code values are unchanged; the FA configuration error is appended as value 16.
- No existing public member is removed, renamed, retyped, or re-signatured.
- Package version: **2.0.93** to be in alignment with the linked PRs. Update required with version drift. 

## Validation

- ant clean test jar — passed; 26/26 Java assertions exercised the production checkbox handler, matching rules, desired-state matrix, failure cases, legacy defaults, Group Allocation Warning discovery and suppression, idempotence, column-order handling, case handling, and missing-warning behavior.
- dotnet test IBAutomater.sln -c Release --no-restore — passed; 3/3 C# tests, with both the net10.0 and netstandard2.1 library targets built.
- The live Gateway matrix passed nine production UI/control cases covering establishment of unified mode, the legacy false transition and idempotence, eight-argument false/true transitions and idempotence, native soft restart with true, and explicit restart with true. Managed accounts, orders, and positions were unchanged across restart cases.
- The nine-case live matrix certifies the allocation-group checkbox and restart behavior. The later Group Allocation Warning handling is covered by the current 26-assertion Java production-helper test suite and is not represented as part of that earlier live matrix.
- Coordinated FA-v2 LEAN startups with unified groups set to true, false, and omitted exercised the brokerage-to-IBAutomater handoff before brokerage use.
- The broader linked FA-v2 live-paper campaign completed as documented in the attached verification report.

## Related work and sequencing

The coordinated PRs can be reviewed concurrently, but their release has package and platform dependencies:
1. Merge [this IBAutomater PR](https://github.com/QuantConnect/IBAutomater/pull/115) and publish QuantConnect.IBAutomater 2.0.93.
2. Merge [Lean update](https://github.com/QuantConnect/Lean/pull/9789), which adds the brokerage-neutral FA contracts, default-safe LEAN configuration, and publish the corresponding LEAN packages.
3. Merge [Lean.Brokerages.InteractiveBrokers update](https://github.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/pull/261) against the published IBAutomater and LEAN package surfaces.
4. Add the required deployment schema/UI inputs so Local Platform, LEAN CLI, direct cloud API, and QuantConnect Cloud deployments can emit the exact brokerage settings.
5. Merge [Documentation-update](https://github.com/QuantConnect/Documentation/pull/2679) in alignment with the released implementations and deployment surface.
The hosted deployment schema/UI must expose the unified-groups and group-management inputs under their exact brokerage-data keys. That platform work is external to this repository.

```
IBAutomater PR ──> publish 2.0.93 ───────────────┐
                                                 ├──> IB brokerage PR ─> brokerage release
LEAN PR ────────> publish LEAN 2.5.x packages ───┘                        │
                                                                          ├─> expose deployment inputs
Platform cloud schema/UI work (add 2 inputs)──────────────────────────────┘
                                                                          │
Documentation PR ─────────────────────────────────────────────────────────┘
```
## Files attached explaining the full fav2 linked PR scope across repos, and testing conducted

[fav2_live_verification_report.md](https://github.com/user-attachments/files/32133548/fav2_live_verification_report.md)
[fav2_enhancement_summary.md](https://github.com/user-attachments/files/32133553/fav2_enhancement_summary.md)
[enhancement_change_inventory.md](https://github.com/user-attachments/files/32133549/enhancement_change_inventory.md)
[enhancement_goals_findings.md](https://github.com/user-attachments/files/32133550/enhancement_goals_findings.md)
[enhancement_scope.md](https://github.com/user-attachments/files/32133551/enhancement_scope.md)
[test_file_scope.md](https://github.com/user-attachments/files/32133554/test_file_scope.md)


## Types of changes

- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  Refactor (non-breaking change which improves implementation)
- [ ]  Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)
- [x]  Non-functional change (xml comments/documentation/etc)

## Checklist:

- [x]  My code follows the code style of this project.
- [x]  I have read the CONTRIBUTING [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x]  I have added tests to cover my changes.
- [x]  All new tests passed, along with the existing tests that passed without the feature.
- [x]  My branch follows the naming convention bug-<issue#>-<description> or feature-<issue#>-<description>
